### PR TITLE
Upgrade the support library to 24.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ allprojects {
 }
 
 ext{
-    supportLibraryVersion = '24.2.0'
+    supportLibraryVersion = '24.2.1'
     VERSION_NAME = "0.7.2-SNAPSHOT"
     VERSION_CODE = 2
     MIN_SDK_VERSION = 14

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -32,7 +32,7 @@ android {
 
 dependencies {
     compile project(':thirtyinch')
-    compile 'com.pascalwelsch.compositeandroid:activity:0.2.2'
+    compile "com.pascalwelsch.compositeandroid:activity:$supportLibraryVersion"
 }
 
 publish {


### PR DESCRIPTION
Google recommends the upgrade:

> We do, however, recommend using 24.2.1 over 24.2.0 as it contains a number of bug fixes.
https://www.reddit.com/r/androiddev/comments/52m6ac/android_support_library_revision_2421_released/d7lptza

https://github.com/grandcentrix/ThirtyInch/issues/8