### PR TITLE
Use the same logging interface everywhere

### DIFF
--- a/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiActivityPlugin.java
+++ b/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiActivityPlugin.java
@@ -26,7 +26,7 @@ import net.grandcentrix.thirtyinch.TiView;
 import net.grandcentrix.thirtyinch.internal.DelegatedTiActivity;
 import net.grandcentrix.thirtyinch.internal.InterceptableViewBinder;
 import net.grandcentrix.thirtyinch.internal.TiActivityDelegate;
-import net.grandcentrix.thirtyinch.internal.TiPresenterLogger;
+import net.grandcentrix.thirtyinch.internal.TiLoggingTagProvider;
 import net.grandcentrix.thirtyinch.internal.TiPresenterProvider;
 import net.grandcentrix.thirtyinch.internal.TiViewProvider;
 import net.grandcentrix.thirtyinch.util.AndroidDeveloperOptions;
@@ -37,12 +37,11 @@ import android.content.res.Configuration;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.util.Log;
 
 import java.util.List;
 
 public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extends ActivityPlugin
-        implements TiViewProvider<V>, DelegatedTiActivity<P>, TiPresenterLogger,
+        implements TiViewProvider<V>, DelegatedTiActivity<P>, TiLoggingTagProvider,
         InterceptableViewBinder<V> {
 
     public static final String NCI_KEY_PRESENTER = "presenter";
@@ -93,6 +92,11 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
         return mDelegate.getInterceptors(predicate);
     }
 
+    @Override
+    public String getLoggingTag() {
+        return TAG;
+    }
+
     public P getPresenter() {
         return mDelegate.getPresenter();
     }
@@ -125,11 +129,6 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
     @Override
     public boolean isDontKeepActivitiesEnabled() {
         return AndroidDeveloperOptions.isDontKeepActivitiesEnabled(getActivity());
-    }
-
-    @Override
-    public void logTiMessages(final String msg) {
-        Log.v(TAG, msg);
     }
 
     @Override

--- a/rx/src/test/java/net/grandcentrix/thirtyinch/rx/RxUtilsTest.java
+++ b/rx/src/test/java/net/grandcentrix/thirtyinch/rx/RxUtilsTest.java
@@ -15,6 +15,7 @@
 
 package net.grandcentrix.thirtyinch.rx;
 
+import net.grandcentrix.thirtyinch.TiLog;
 import net.grandcentrix.thirtyinch.TiView;
 
 import org.junit.After;
@@ -44,6 +45,13 @@ public class RxUtilsTest {
 
     @Before
     public void setUp() throws Exception {
+        TiLog.setLogger(new TiLog.Logger() {
+            @Override
+            public void log(final int level, final String tag, final String msg) {
+                // prevent RuntimeException: android.util.Log not mocked
+            }
+        });
+
         mView = mock(TiView.class);
 
         mPresenter = new TiMockPresenter();

--- a/sample/src/main/java/net/grandcentrix/thirtyinch/sample/HelloWorldActivity.java
+++ b/sample/src/main/java/net/grandcentrix/thirtyinch/sample/HelloWorldActivity.java
@@ -19,6 +19,7 @@ package net.grandcentrix.thirtyinch.sample;
 import com.jakewharton.rxbinding.view.RxView;
 
 import net.grandcentrix.thirtyinch.TiActivity;
+import net.grandcentrix.thirtyinch.TiLog;
 
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -35,6 +36,10 @@ public class HelloWorldActivity extends TiActivity<HelloWorldPresenter, HelloWor
     private TextView mOutput;
 
     private TextView mUptime;
+
+    public HelloWorldActivity() {
+        TiLog.setLogger(TiLog.LOGCAT);
+    }
 
     @Override
     public Observable<Void> onButtonClicked() {

--- a/thirtyinch/build.gradle
+++ b/thirtyinch/build.gradle
@@ -37,7 +37,6 @@ android {
 
 dependencies {
     compile "com.android.support:appcompat-v7:$supportLibraryVersion"
-    compile "com.jakewharton.timber:timber:4.3.1"
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'

--- a/thirtyinch/build.gradle
+++ b/thirtyinch/build.gradle
@@ -37,6 +37,7 @@ android {
 
 dependencies {
     compile "com.android.support:appcompat-v7:$supportLibraryVersion"
+    compile "com.jakewharton.timber:timber:4.3.1"
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'

--- a/thirtyinch/src/androidTest/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegateTest.java
+++ b/thirtyinch/src/androidTest/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegateTest.java
@@ -15,8 +15,8 @@
 
 package net.grandcentrix.thirtyinch.internal;
 
-import net.grandcentrix.thirtyinch.TiPresenter;
 import net.grandcentrix.thirtyinch.TiConfiguration;
+import net.grandcentrix.thirtyinch.TiPresenter;
 import net.grandcentrix.thirtyinch.TiView;
 
 import org.junit.Before;
@@ -144,38 +144,6 @@ public class TiActivityDelegateTest {
     }
 
     @Test
-    public void testRestorePresenter_withSavior_whichIsDisabled() throws Exception {
-        final TiPresenter firstPresenter = new TiPresenter(new TiConfiguration.Builder()
-                .setUseStaticSaviorToRetain(false)
-                .build()) {
-        };
-        final TiPresenter secondPresenter = new TiPresenter(new TiConfiguration.Builder()
-                .setUseStaticSaviorToRetain(false)
-                .build()) {
-        };
-        mPresenter = firstPresenter;
-
-        mDelegate.onCreate_afterSuper(null);
-
-        assertEquals(TiPresenter.State.CREATED_WITH_DETACHED_VIEW, mPresenter.getState());
-
-        final Bundle bundle = new Bundle();
-        mDelegate.onSaveInstanceState_afterSuper(bundle);
-
-        mDelegate.onDestroy_afterSuper();
-        assertEquals(TiPresenter.State.CREATED_WITH_DETACHED_VIEW, mPresenter.getState());
-
-        mPresenter = secondPresenter;
-
-        // check reuse of old presenter
-        mDelegate.onCreate_afterSuper(bundle);
-        assertEquals(secondPresenter, mDelegate.getPresenter());
-
-        // new one got created
-        assertEquals(TiPresenter.State.CREATED_WITH_DETACHED_VIEW, mPresenter.getState());
-    }
-
-    @Test
     public void testRestorePresenter_withSavior() throws Exception {
         final TiPresenter firstPresenter = new TiPresenter(new TiConfiguration.Builder()
                 .setUseStaticSaviorToRetain(true)
@@ -205,6 +173,38 @@ public class TiActivityDelegateTest {
 
         // new one got NOT created
         assertEquals(TiPresenter.State.INITIALIZED, mPresenter.getState());
+    }
+
+    @Test
+    public void testRestorePresenter_withSavior_whichIsDisabled() throws Exception {
+        final TiPresenter firstPresenter = new TiPresenter(new TiConfiguration.Builder()
+                .setUseStaticSaviorToRetain(false)
+                .build()) {
+        };
+        final TiPresenter secondPresenter = new TiPresenter(new TiConfiguration.Builder()
+                .setUseStaticSaviorToRetain(false)
+                .build()) {
+        };
+        mPresenter = firstPresenter;
+
+        mDelegate.onCreate_afterSuper(null);
+
+        assertEquals(TiPresenter.State.CREATED_WITH_DETACHED_VIEW, mPresenter.getState());
+
+        final Bundle bundle = new Bundle();
+        mDelegate.onSaveInstanceState_afterSuper(bundle);
+
+        mDelegate.onDestroy_afterSuper();
+        assertEquals(TiPresenter.State.CREATED_WITH_DETACHED_VIEW, mPresenter.getState());
+
+        mPresenter = secondPresenter;
+
+        // check reuse of old presenter
+        mDelegate.onCreate_afterSuper(bundle);
+        assertEquals(secondPresenter, mDelegate.getPresenter());
+
+        // new one got created
+        assertEquals(TiPresenter.State.CREATED_WITH_DETACHED_VIEW, mPresenter.getState());
     }
 
     @NonNull
@@ -249,10 +249,10 @@ public class TiActivityDelegateTest {
                         return mPresenter;
                     }
                 },
-                new TiPresenterLogger() {
+                new TiLoggingTagProvider() {
                     @Override
-                    public void logTiMessages(final String msg) {
-                        System.out.println(msg);
+                    public String getLoggingTag() {
+                        return "TestTag";
                     }
                 });
     }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
@@ -19,7 +19,7 @@ import net.grandcentrix.thirtyinch.internal.DelegatedTiActivity;
 import net.grandcentrix.thirtyinch.internal.InterceptableViewBinder;
 import net.grandcentrix.thirtyinch.internal.PresenterNonConfigurationInstance;
 import net.grandcentrix.thirtyinch.internal.TiActivityDelegate;
-import net.grandcentrix.thirtyinch.internal.TiPresenterLogger;
+import net.grandcentrix.thirtyinch.internal.TiLoggingTagProvider;
 import net.grandcentrix.thirtyinch.internal.TiPresenterProvider;
 import net.grandcentrix.thirtyinch.internal.TiViewProvider;
 import net.grandcentrix.thirtyinch.util.AndroidDeveloperOptions;
@@ -30,7 +30,6 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
-import android.util.Log;
 
 import java.util.List;
 
@@ -40,7 +39,7 @@ import java.util.List;
 public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
         extends AppCompatActivity
         implements TiPresenterProvider<P>, TiViewProvider<V>, DelegatedTiActivity<P>,
-        TiPresenterLogger, InterceptableViewBinder<V> {
+        TiLoggingTagProvider, InterceptableViewBinder<V> {
 
     private final String TAG = this.getClass().getSimpleName()
             + ":" + TiActivity.class.getSimpleName()
@@ -66,6 +65,11 @@ public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
     public List<BindViewInterceptor> getInterceptors(
             @NonNull final Filter<BindViewInterceptor> predicate) {
         return mDelegate.getInterceptors(predicate);
+    }
+
+    @Override
+    public String getLoggingTag() {
+        return TAG;
     }
 
     public P getPresenter() {
@@ -103,11 +107,6 @@ public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
     @Override
     public boolean isDontKeepActivitiesEnabled() {
         return AndroidDeveloperOptions.isDontKeepActivitiesEnabled(this);
-    }
-
-    @Override
-    public void logTiMessages(final String msg) {
-        Log.v(TAG, msg);
     }
 
     @Override

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiFragment.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiFragment.java
@@ -20,7 +20,7 @@ import net.grandcentrix.thirtyinch.distinctuntilchanged.DistinctUntilChangedInte
 import net.grandcentrix.thirtyinch.internal.InterceptableViewBinder;
 import net.grandcentrix.thirtyinch.internal.PresenterSavior;
 import net.grandcentrix.thirtyinch.internal.PresenterViewBinder;
-import net.grandcentrix.thirtyinch.internal.TiPresenterLogger;
+import net.grandcentrix.thirtyinch.internal.TiLoggingTagProvider;
 import net.grandcentrix.thirtyinch.internal.TiPresenterProvider;
 import net.grandcentrix.thirtyinch.internal.TiViewProvider;
 import net.grandcentrix.thirtyinch.util.AndroidDeveloperOptions;
@@ -32,7 +32,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -40,7 +39,7 @@ import android.view.ViewGroup;
 import java.util.List;
 
 public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView>
-        extends Fragment implements TiPresenterProvider<P>, TiPresenterLogger,
+        extends Fragment implements TiPresenterProvider<P>, TiLoggingTagProvider,
         TiViewProvider<V>, InterceptableViewBinder<V> {
 
     private static final String SAVED_STATE_PRESENTER_ID = "presenter_id";
@@ -76,6 +75,11 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView>
         return mViewBinder.getInterceptors(predicate);
     }
 
+    @Override
+    public String getLoggingTag() {
+        return TAG;
+    }
+
     public P getPresenter() {
         return mPresenter;
     }
@@ -90,21 +94,16 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView>
     }
 
     @Override
-    public void logTiMessages(final String msg) {
-        Log.v(TAG, msg);
-    }
-
-    @Override
     public void onAttach(final Activity activity) {
         super.onAttach(activity);
-        Log.v(TAG, "onAttach()");
+        TiLog.v(TAG, "onAttach()");
 
     }
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Log.d(TAG, "onCreate(" + savedInstanceState + ")");
+        TiLog.d(TAG, "onCreate(" + savedInstanceState + ")");
 
         if (mPresenter == null && savedInstanceState != null) {
             // recover with Savior
@@ -112,7 +111,7 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView>
             final String recoveredPresenterId = savedInstanceState
                     .getString(SAVED_STATE_PRESENTER_ID);
             if (recoveredPresenterId != null) {
-                Log.d(TAG, "try to recover Presenter with id: " + recoveredPresenterId);
+                TiLog.d(TAG, "try to recover Presenter with id: " + recoveredPresenterId);
                 //noinspection unchecked
                 mPresenter = (P) PresenterSavior.INSTANCE.recover(recoveredPresenterId);
                 if (mPresenter != null) {
@@ -122,13 +121,13 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView>
                     PresenterSavior.INSTANCE.free(recoveredPresenterId);
                     mPresenterId = PresenterSavior.INSTANCE.safe(mPresenter);
                 }
-                Log.d(TAG, "recovered Presenter " + mPresenter);
+                TiLog.d(TAG, "recovered Presenter " + mPresenter);
             }
         }
 
         if (mPresenter == null) {
             mPresenter = providePresenter();
-            Log.d(TAG, "created Presenter: " + mPresenter);
+            TiLog.d(TAG, "created Presenter: " + mPresenter);
             final TiConfiguration config = mPresenter.getConfig();
             if (config.shouldRetainPresenter() && config.useStaticSaviorToRetain()) {
                 mPresenterId = PresenterSavior.INSTANCE.safe(mPresenter);
@@ -162,7 +161,7 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView>
     public void onDestroy() {
         super.onDestroy();
         final FragmentActivity activity = getActivity();
-        Log.v(TAG, "onDestroy() recreating=" + !activity.isFinishing());
+        TiLog.v(TAG, "onDestroy() recreating=" + !activity.isFinishing());
 
         boolean destroyPresenter = false;
         if (activity.isFinishing()) {
@@ -197,7 +196,7 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView>
 
     @Override
     public void onDestroyView() {
-        Log.v(TAG, "onDestroyView()");
+        TiLog.v(TAG, "onDestroyView()");
         mPresenter.sleep();
         super.onDestroyView();
     }
@@ -205,7 +204,7 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView>
     @Override
     public void onDetach() {
         super.onDetach();
-        Log.v(TAG, "onDetach()");
+        TiLog.v(TAG, "onDetach()");
     }
 
     @Override
@@ -217,7 +216,7 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView>
     @Override
     public void onStart() {
         super.onStart();
-        Log.v(TAG, "onStart()");
+        TiLog.v(TAG, "onStart()");
         mActivityStarted = true;
 
         if (isUiPossible()) {
@@ -235,7 +234,7 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView>
 
     @Override
     public void onStop() {
-        Log.v(TAG, "onStop()");
+        TiLog.v(TAG, "onStop()");
         mActivityStarted = false;
         mPresenter.sleep();
         super.onStop();

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiLog.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiLog.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2016 grandcentrix GmbH
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.grandcentrix.thirtyinch;
+
+
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import timber.log.Timber;
+
+/**
+ * Logging class used for all logging of ThirtyInch.
+ */
+public class TiLog {
+
+    /**
+     * Simple logging interface for log messages from ThirtyInch
+     *
+     * @see #setLogger(Logger)
+     */
+    interface Logger {
+
+        /**
+         * @param level one of {@link Log#VERBOSE}, {@link Log#DEBUG},{@link Log#INFO},
+         *              {@link Log#WARN},{@link Log#ERROR}
+         * @param tag   log tag, caller
+         * @param msg   message to log
+         */
+        void log(final int level, final String tag, final String msg);
+    }
+
+    // logs everything to Timber by default
+    private static Logger logger = new Logger() {
+        @Override
+        public void log(final int level, final String tag, final String msg) {
+            Timber.tag(tag).log(level, msg);
+        }
+    };
+
+    public static void d(final String tag, final String msg) {
+        if (logger != null) {
+            logger.log(Log.DEBUG, tag, msg);
+        }
+    }
+
+    public static void e(final String tag, final String msg) {
+        if (logger != null) {
+            logger.log(Log.ERROR, tag, msg);
+        }
+    }
+
+    public static void i(final String tag, final String msg) {
+        if (logger != null) {
+            logger.log(Log.INFO, tag, msg);
+        }
+    }
+
+    /**
+     * set a custom logger, {@code null} to disable logging
+     */
+    public static void setLogger(@Nullable final Logger logger) {
+        TiLog.logger = logger;
+    }
+
+    public static void v(final String tag, final String msg) {
+        if (logger != null) {
+            logger.log(Log.VERBOSE, tag, msg);
+        }
+    }
+
+    public static void w(final String tag, final String msg) {
+        if (logger != null) {
+            logger.log(Log.WARN, tag, msg);
+        }
+    }
+
+    TiLog() {
+        throw new AssertionError("no instances");
+    }
+}

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiLog.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiLog.java
@@ -114,7 +114,7 @@ public class TiLog {
         }
     }
 
-    TiLog() {
+    private TiLog() {
         throw new AssertionError("no instances");
     }
 }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiLog.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiLog.java
@@ -42,13 +42,19 @@ public class TiLog {
 
     private static final String TAG = "ThirtyInch";
 
-    // logs everything to Timber by default
-    private static Logger logger = new Logger() {
+    /**
+     * predefined logger using {@link Log} to print into Logcat with tag "ThirtyInch"
+     *
+     * @see #setLogger(Logger)
+     */
+    public static Logger LOGCAT = new Logger() {
         @Override
         public void log(final int level, final String tag, final String msg) {
             Log.println(level, TAG, tag + ": " + msg);
         }
     };
+
+    private static Logger logger;
 
     public static void d(final String tag, final String msg) {
         if (logger != null) {
@@ -70,6 +76,14 @@ public class TiLog {
 
     /**
      * set a custom logger, {@code null} to disable logging
+     * <p>
+     *
+     * Use the default logcat logger for Android:
+     * <code>
+     * <pre>
+     * TiLog.setLogger(TiLog.LOGCAT);
+     * </pre>
+     * </code>
      * <p>
      * Combine it with Timber:<br>
      *

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiLog.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiLog.java
@@ -29,7 +29,7 @@ public class TiLog {
      *
      * @see #setLogger(Logger)
      */
-    interface Logger {
+    public interface Logger {
 
         /**
          * @param level one of {@link Log#VERBOSE}, {@link Log#DEBUG},{@link Log#INFO},

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiLog.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiLog.java
@@ -70,6 +70,19 @@ public class TiLog {
 
     /**
      * set a custom logger, {@code null} to disable logging
+     * <p>
+     * Combine it with Timber:<br>
+     *
+     * <code>
+     * <pre>
+     * TiLog.setLogger(new TiLog.Logger() {
+     *    &#64;Override
+     *    public void log(final int level, final String tag, final String msg) {
+     *        Timber.tag(tag).log(level, msg);
+     *    }
+     * });
+     * </pre>
+     * </code>
      */
     public static void setLogger(@Nullable final Logger logger) {
         TiLog.logger = logger;

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiLog.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiLog.java
@@ -19,8 +19,6 @@ package net.grandcentrix.thirtyinch;
 import android.support.annotation.Nullable;
 import android.util.Log;
 
-import timber.log.Timber;
-
 /**
  * Logging class used for all logging of ThirtyInch.
  */
@@ -42,11 +40,13 @@ public class TiLog {
         void log(final int level, final String tag, final String msg);
     }
 
+    private static final String TAG = "ThirtyInch";
+
     // logs everything to Timber by default
     private static Logger logger = new Logger() {
         @Override
         public void log(final int level, final String tag, final String msg) {
-            Timber.tag(tag).log(level, msg);
+            Log.println(level, TAG, tag + ": " + msg);
         }
     };
 

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
@@ -25,8 +25,6 @@ import android.support.v4.app.Fragment;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Represents the Presenter of the popular Model-View-Presenter design pattern. If used with {@link
@@ -70,9 +68,9 @@ public abstract class TiPresenter<V extends TiView> {
     @VisibleForTesting
     final List<TiLifecycleObserver> mLifecycleObservers = new ArrayList<>();
 
-    Logger mLogger = Logger.getLogger(this.getClass().getSimpleName()
+    private final String TAG = this.getClass().getSimpleName()
             + ":" + TiPresenter.class.getSimpleName()
-            + "@" + Integer.toHexString(this.hashCode()));
+            + "@" + Integer.toHexString(this.hashCode());
 
     /**
      * used to check that lifecycle methods (starting with on..) cannot be called directly. i.e.
@@ -174,12 +172,12 @@ public abstract class TiPresenter<V extends TiView> {
      */
     public final void create() {
         if (isCreated()) {
-            mLogger.log(Level.WARNING, "not calling onCreate(), it was already called");
+            TiLog.w(TAG, "not calling onCreate(), it was already called");
             return;
         }
         moveToState(State.CREATED_WITH_DETACHED_VIEW, false);
         mCalled = false;
-        mLogger.log(Level.FINE, "onCreate()");
+        TiLog.v(TAG, "onCreate()");
         onCreate();
         if (!mCalled) {
             throw new SuperNotCalledException("Presenter " + this
@@ -197,13 +195,13 @@ public abstract class TiPresenter<V extends TiView> {
      */
     public final void destroy() {
         if (!isCreated() || isDestroyed()) {
-            mLogger.log(Level.WARNING, "not calling onDestroy(), destroy was already called");
+           TiLog.w(TAG, "not calling onDestroy(), destroy was already called");
             return;
         }
 
         moveToState(State.DESTROYED, false);
         mCalled = false;
-        mLogger.log(Level.FINE, "onDestroy()");
+        TiLog.v(TAG, "onDestroy()");
         onDestroy();
         if (!mCalled) {
             throw new SuperNotCalledException("Presenter " + this
@@ -259,12 +257,12 @@ public abstract class TiPresenter<V extends TiView> {
      */
     public final void sleep() {
         if (!isAwake()) {
-            mLogger.log(Level.FINE, "not calling onSleep(), not woken up");
+            TiLog.v(TAG, "not calling onSleep(), not woken up");
             return;
         }
         moveToState(State.CREATED_WITH_DETACHED_VIEW, false);
         mCalled = false;
-        mLogger.log(Level.FINE, "onSleep()");
+        TiLog.v(TAG, "onSleep()");
         onSleep();
         if (!mCalled) {
             throw new SuperNotCalledException("Presenter " + this
@@ -297,12 +295,12 @@ public abstract class TiPresenter<V extends TiView> {
      */
     public final void wakeUp() {
         if (isAwake()) {
-            mLogger.log(Level.FINE, "not calling onWakeUp(), already woken up");
+            TiLog.v(TAG, "not calling onWakeUp(), already woken up");
             return;
         }
         moveToState(State.VIEW_ATTACHED_AND_AWAKE, false);
         mCalled = false;
-        mLogger.log(Level.FINE, "onWakeUp()");
+        TiLog.v(TAG, "onWakeUp()");
         onWakeUp();
         if (!mCalled) {
             throw new SuperNotCalledException("Presenter " + this

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/callonmainthread/CallOnMainThreadInterceptor.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/callonmainthread/CallOnMainThreadInterceptor.java
@@ -16,9 +16,8 @@
 package net.grandcentrix.thirtyinch.callonmainthread;
 
 import net.grandcentrix.thirtyinch.BindViewInterceptor;
+import net.grandcentrix.thirtyinch.TiLog;
 import net.grandcentrix.thirtyinch.TiView;
-
-import android.util.Log;
 
 import java.lang.reflect.Proxy;
 
@@ -32,7 +31,7 @@ public class CallOnMainThreadInterceptor implements BindViewInterceptor {
     @Override
     public <V extends TiView> V intercept(final V view) {
         final V wrapped = wrap(view);
-        Log.d(TAG, "wrapping View " + view + " in " + wrapped);
+        TiLog.d(TAG, "wrapping View " + view + " in " + wrapped);
         return wrapped;
     }
 

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInterceptor.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInterceptor.java
@@ -16,12 +16,12 @@
 package net.grandcentrix.thirtyinch.distinctuntilchanged;
 
 import net.grandcentrix.thirtyinch.BindViewInterceptor;
+import net.grandcentrix.thirtyinch.TiLog;
 import net.grandcentrix.thirtyinch.TiView;
 import net.grandcentrix.thirtyinch.internal.InterceptableViewBinder;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.util.Log;
 
 import java.lang.reflect.Proxy;
 
@@ -49,7 +49,7 @@ public class DistinctUntilChangedInterceptor implements BindViewInterceptor {
                     = DistinctUntilChangedInterceptor.unwrap(wrappedView);
             if (view != null) {
                 view.clearCache();
-                Log.v(TAG, "cleared the distinctUntilChanged cache of " + view);
+                TiLog.v(TAG, "cleared the distinctUntilChanged cache of " + view);
             }
         }
     }
@@ -57,7 +57,7 @@ public class DistinctUntilChangedInterceptor implements BindViewInterceptor {
     @Override
     public <V extends TiView> V intercept(final V view) {
         final V wrapped = wrap(view);
-        Log.d(TAG, "wrapping View " + view + " in " + wrapped);
+        TiLog.d(TAG, "wrapping View " + view + " in " + wrapped);
         return wrapped;
     }
 

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandler.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandler.java
@@ -15,6 +15,7 @@
 
 package net.grandcentrix.thirtyinch.distinctuntilchanged;
 
+import net.grandcentrix.thirtyinch.TiLog;
 import net.grandcentrix.thirtyinch.TiView;
 import net.grandcentrix.thirtyinch.util.AbstractInvocationHandler;
 
@@ -22,20 +23,17 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 final class DistinctUntilChangedInvocationHandler<V> extends AbstractInvocationHandler {
 
-    private HashMap<String, Integer> mLatestMethodCalls = new HashMap<>();
+    private static final String TAG = DistinctUntilChangedInvocationHandler.class.getSimpleName();
 
-    private final Logger mLogger;
+    private HashMap<String, Integer> mLatestMethodCalls = new HashMap<>();
 
     private final V mView;
 
     public DistinctUntilChangedInvocationHandler(V view) {
         mView = view;
-        mLogger = Logger.getLogger(toString());
     }
 
     public void clearCache() {
@@ -102,7 +100,7 @@ final class DistinctUntilChangedInvocationHandler<V> extends AbstractInvocationH
             } else {
                 // don't call the method, the exact same data was already sent to the view
                 if (ducAnnotation.logDropped()) {
-                    mLogger.log(Level.INFO, "not calling " + method
+                    TiLog.d(TAG, "not calling " + method
                             + " with args " + Arrays.toString(args) + "."
                             + " Was already called with the same parameters before.");
                 }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/PresenterSavior.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/PresenterSavior.java
@@ -16,14 +16,13 @@
 package net.grandcentrix.thirtyinch.internal;
 
 import net.grandcentrix.thirtyinch.TiActivity;
+import net.grandcentrix.thirtyinch.TiLog;
 import net.grandcentrix.thirtyinch.TiPresenter;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import java.util.HashMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Activities can be destroyed when the device runs out of memory. Sometimes it doesn't work to
@@ -37,7 +36,7 @@ public enum PresenterSavior {
 
     INSTANCE;
 
-    private Logger mLogger = Logger.getLogger(PresenterSavior.class.getSimpleName());
+    private static final String TAG = PresenterSavior.class.getSimpleName();
 
     private HashMap<String, TiPresenter> mPresenters = new HashMap<>();
 
@@ -52,7 +51,7 @@ public enum PresenterSavior {
 
     public String safe(@NonNull final TiPresenter presenter) {
         final String id = generateId(presenter);
-        mLogger.log(Level.FINER, "safe presenter with id " + id + " " + presenter);
+        TiLog.v(TAG, "safe presenter with id " + id + " " + presenter);
         mPresenters.put(id, presenter);
         return id;
     }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/PresenterViewBinder.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/PresenterViewBinder.java
@@ -17,6 +17,7 @@ package net.grandcentrix.thirtyinch.internal;
 
 import net.grandcentrix.thirtyinch.Removable;
 import net.grandcentrix.thirtyinch.BindViewInterceptor;
+import net.grandcentrix.thirtyinch.TiLog;
 import net.grandcentrix.thirtyinch.TiPresenter;
 import net.grandcentrix.thirtyinch.TiView;
 
@@ -37,17 +38,17 @@ public class PresenterViewBinder<V extends TiView> implements InterceptableViewB
 
     private List<BindViewInterceptor> mBindViewInterceptors = new ArrayList<>();
 
-    private HashMap<BindViewInterceptor, V> mIntercepterViewOutput = new HashMap<>();
+    private HashMap<BindViewInterceptor, V> mInterceptorViewOutput = new HashMap<>();
 
     /**
      * the cached version of the view send to the presenter after it passed the interceptors
      */
     private V mLastView;
 
-    private final TiPresenterLogger mLogger;
+    private final TiLoggingTagProvider mLogTag;
 
-    public PresenterViewBinder(final TiPresenterLogger logger) {
-        mLogger = logger;
+    public PresenterViewBinder(final TiLoggingTagProvider loggingTagProvider) {
+        mLogTag = loggingTagProvider;
     }
 
     @NonNull
@@ -75,13 +76,13 @@ public class PresenterViewBinder<V extends TiView> implements InterceptableViewB
             V interceptedView = viewProvider.provideView();
             for (final BindViewInterceptor interceptor : mBindViewInterceptors) {
                 interceptedView = interceptor.intercept(interceptedView);
-                mIntercepterViewOutput.put(interceptor, interceptedView);
+                mInterceptorViewOutput.put(interceptor, interceptedView);
             }
             mLastView = interceptedView;
-            mLogger.logTiMessages("binding NEW view to Presenter " + mLastView);
+            TiLog.v(mLogTag.getLoggingTag(), "binding NEW view to Presenter " + mLastView);
             presenter.bindNewView(mLastView);
         } else {
-            mLogger.logTiMessages("binding the cached view to Presenter " + mLastView);
+            TiLog.v(mLogTag.getLoggingTag(), "binding the cached view to Presenter " + mLastView);
             presenter.bindNewView(mLastView);
         }
     }
@@ -89,7 +90,7 @@ public class PresenterViewBinder<V extends TiView> implements InterceptableViewB
     @Nullable
     @Override
     public V getInterceptedViewOf(@NonNull final BindViewInterceptor interceptor) {
-        return mIntercepterViewOutput.get(interceptor);
+        return mInterceptorViewOutput.get(interceptor);
     }
 
     @NonNull
@@ -109,6 +110,6 @@ public class PresenterViewBinder<V extends TiView> implements InterceptableViewB
     @Override
     public void invalidateView() {
         mLastView = null;
-        mIntercepterViewOutput.clear();
+        mInterceptorViewOutput.clear();
     }
 }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiLoggingTagProvider.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiLoggingTagProvider.java
@@ -15,19 +15,14 @@
 
 package net.grandcentrix.thirtyinch.internal;
 
-import net.grandcentrix.thirtyinch.TiActivity;
-
 /**
- * Super simple logging interface because the {@link TiActivityDelegate}
- * is not responsible for actually logging. The using {@link TiActivity}
- * or {@code TiActivityPlugin} takes care of logging and providing the correct logging TAG.
+ * Interface providing access to a logging tag for composition classes. Provides better tags for
+ * the log output
  */
-public interface TiPresenterLogger {
+public interface TiLoggingTagProvider {
 
     /**
-     * logs a debug message from the presenter
-     *
-     * @param msg message from the presenter to display
+     * @return the tag which should be used for logging
      */
-    void logTiMessages(final String msg);
+    String getLoggingTag();
 }

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/TiLifecycleObserverTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/TiLifecycleObserverTest.java
@@ -34,6 +34,12 @@ public class TiLifecycleObserverTest {
 
     @Before
     public void setUp() throws Exception {
+        TiLog.setLogger(new TiLog.Logger() {
+            @Override
+            public void log(final int level, final String tag, final String msg) {
+                // prevent RuntimeException: android.util.Log not mocked
+            }
+        });
         mView = mock(TiView.class);
         mPresenter = new TiMockPresenter();
     }

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/TiPresenterTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/TiPresenterTest.java
@@ -39,6 +39,12 @@ public class TiPresenterTest {
 
     @Before
     public void setUp() throws Exception {
+        TiLog.setLogger(new TiLog.Logger() {
+            @Override
+            public void log(final int level, final String tag, final String msg) {
+                // prevent RuntimeException: android.util.Log not mocked
+            }
+        });
         mView = mock(TiView.class);
         mPresenter = new TiMockPresenter();
     }


### PR DESCRIPTION
`TiLog.setLogger(null)`
- allows custom loggers
- disable logging is now possible

Fixes logging with `java.util.logging.Logger` not being visible because the where printed with log level `FINE` which is not printed when the library isn't in debug mode.

issues #13 

combine with Timber:

```java
Timber.plant(new Timber.DebugTree());
TiLog.setLogger(new TiLog.Logger() {
    @Override
    public void log(final int level, final String tag, final String msg) {
        Timber.tag(tag).log(level, msg);
    }
});
```