### PR TITLE
Use equals() instead of hashCode() for comparing arguments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandler.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandler.java
@@ -33,11 +33,11 @@ final class DistinctUntilChangedInvocationHandler<V> extends AbstractInvocationH
 
     private final V mView;
 
-    DistinctUntilChangedInvocationHandler(V view) {
+    public DistinctUntilChangedInvocationHandler(V view) {
         mView = view;
     }
 
-    void clearCache() {
+    public void clearCache() {
         mLatestMethodCalls.clear();
     }
 

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandler.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandler.java
@@ -28,15 +28,15 @@ final class DistinctUntilChangedInvocationHandler<V> extends AbstractInvocationH
 
     private static final String TAG = DistinctUntilChangedInvocationHandler.class.getSimpleName();
 
-    private HashMap<String, Integer> mLatestMethodCalls = new HashMap<>();
+    private HashMap<String, Object[]> mLatestMethodCalls = new HashMap<>();
 
     private final V mView;
 
-    public DistinctUntilChangedInvocationHandler(V view) {
+    DistinctUntilChangedInvocationHandler(V view) {
         mView = view;
     }
 
-    public void clearCache() {
+    void clearCache() {
         mLatestMethodCalls.clear();
     }
 
@@ -82,20 +82,19 @@ final class DistinctUntilChangedInvocationHandler<V> extends AbstractInvocationH
             }
 
             final String methodName = method.toGenericString();
-            final int hashNow = Arrays.hashCode(args);
 
             if (!mLatestMethodCalls.containsKey(methodName)) {
                 // first call to method
                 Object result = method.invoke(mView, args);
-                mLatestMethodCalls.put(methodName, hashNow);
+                mLatestMethodCalls.put(methodName, args);
                 return result;
             }
 
-            final Integer hashBefore = mLatestMethodCalls.get(methodName);
-            if (hashBefore != hashNow) {
+            final Object[] argsBefore = mLatestMethodCalls.get(methodName);
+            if (!Arrays.equals(argsBefore, args)) {
                 // arguments changed, call the method
                 Object result = method.invoke(mView, args);
-                mLatestMethodCalls.put(methodName, hashNow);
+                mLatestMethodCalls.put(methodName, args);
                 return result;
             } else {
                 // don't call the method, the exact same data was already sent to the view

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandlerTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandlerTest.java
@@ -13,21 +13,21 @@ public class DistinctUntilChangedInvocationHandlerTest {
 
     private static class TestView implements TiView {
         int callCount;
+
         @DistinctUntilChanged
         public void ducMethod(String param) {
             callCount++;
         }
     }
 
-    TestView ducView;
-    DistinctUntilChangedInvocationHandler<TestView> handler;
+    private TestView ducView;
+    private DistinctUntilChangedInvocationHandler<TestView> handler;
 
     @Before
     public void setUp() {
         ducView = new TestView();
         handler = new DistinctUntilChangedInvocationHandler<>(ducView);
     }
-
 
     @Test
     public void shouldCallMethodTwice() throws Throwable {
@@ -43,7 +43,6 @@ public class DistinctUntilChangedInvocationHandlerTest {
         assertEquals(2, ducView.callCount);
     }
 
-
     @Test
     public void shouldCallMethodOnce() throws Throwable {
         //given
@@ -55,6 +54,27 @@ public class DistinctUntilChangedInvocationHandlerTest {
 
         //then
         assertEquals(1, ducView.callCount);
+    }
+
+
+    @Test
+    public void shouldCallMethodAfterReferenceIsDropped() throws Throwable {
+        //given
+        Method method = ducView.getClass().getMethod("ducMethod", String.class);
+        Object[] args = new Object[]{"p1"};
+
+
+        //when
+        handler.handleInvocation(null, method, args);
+        handler.handleInvocation(null, method, args);
+        //noinspection UnusedAssignment
+        args = null;
+        //try to clear references
+        System.gc();
+        handler.handleInvocation(null, method, new Object[]{"new param"});
+
+        //then
+        assertEquals(2, ducView.callCount);
     }
 
 }

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandlerTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandlerTest.java
@@ -71,6 +71,8 @@ public class DistinctUntilChangedInvocationHandlerTest {
         args = null;
         //try to clear references
         System.gc();
+        handler.clearCache();
+
         handler.handleInvocation(null, method, new Object[]{"new param"});
 
         //then

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandlerTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandlerTest.java
@@ -1,0 +1,60 @@
+package net.grandcentrix.thirtyinch.distinctuntilchanged;
+
+import net.grandcentrix.thirtyinch.TiView;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertEquals;
+
+public class DistinctUntilChangedInvocationHandlerTest {
+
+    private static class TestView implements TiView {
+        int callCount;
+        @DistinctUntilChanged
+        public void ducMethod(String param) {
+            callCount++;
+        }
+    }
+
+    TestView ducView;
+    DistinctUntilChangedInvocationHandler<TestView> handler;
+
+    @Before
+    public void setUp() {
+        ducView = new TestView();
+        handler = new DistinctUntilChangedInvocationHandler<>(ducView);
+    }
+
+
+    @Test
+    public void shouldCallMethodTwice() throws Throwable {
+        //given
+        Method method = ducView.getClass().getMethod("ducMethod", String.class);
+
+        //when
+        handler.handleInvocation(null, method, new Object[]{"test string 1"});
+        handler.handleInvocation(null, method, new Object[]{"test string 2"});
+        handler.handleInvocation(null, method, new Object[]{"test string 2"});
+
+        //then
+        assertEquals(2, ducView.callCount);
+    }
+
+
+    @Test
+    public void shouldCallMethodOnce() throws Throwable {
+        //given
+        Method method = ducView.getClass().getMethod("ducMethod", String.class);
+
+        //when
+        handler.handleInvocation(null, method, new Object[]{"test string 1"});
+        handler.handleInvocation(null, method, new Object[]{"test string 1"});
+
+        //then
+        assertEquals(1, ducView.callCount);
+    }
+
+}


### PR DESCRIPTION
Use equals() for comparing arguments instead of using hashCode() in `DistinctUntilChangedInvocationHandler`.

Update grade plugin to latest version and do small code cleanup
