### PR TITLE
DistinctUntilChanged with different comparisons

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/sample/src/main/java/net/grandcentrix/thirtyinch/sample/HelloWorldPresenter.java
+++ b/sample/src/main/java/net/grandcentrix/thirtyinch/sample/HelloWorldPresenter.java
@@ -56,16 +56,16 @@ public class HelloWorldPresenter extends TiPresenter<HelloWorldView> {
                 }));
 
         rxSubscriptionHelper.manageSubscription(triggerHeavyCalculation
-                .doOnNext(new Action1<Void>() {
-                    @Override
-                    public void call(final Void aVoid) {
-                        mText.onNext("calculating next number...");
-                    }
-                })
                 .onBackpressureDrop(new Action1<Void>() {
                     @Override
                     public void call(final Void aVoid) {
                         mText.onNext("Don't hurry me!");
+                    }
+                })
+                .doOnNext(new Action1<Void>() {
+                    @Override
+                    public void call(final Void aVoid) {
+                        mText.onNext("calculating next number...");
                     }
                 })
                 .flatMap(new Func1<Void, Observable<Integer>>() {

--- a/thirtyinch/build.gradle
+++ b/thirtyinch/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'
+    testCompile 'org.assertj:assertj-core:1.7.1'
 
     androidTestCompile 'com.android.support.test:runner:0.4'
     androidTestCompile 'org.mockito:mockito-core:1.10.19'

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctComparator.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctComparator.java
@@ -1,0 +1,6 @@
+package net.grandcentrix.thirtyinch.distinctuntilchanged;
+
+public interface DistinctComparator {
+
+    boolean isEqual(final Object[] newParameters);
+}

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctComparator.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctComparator.java
@@ -1,6 +1,34 @@
+/*
+ * Copyright (C) 2016 grandcentrix GmbH
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.grandcentrix.thirtyinch.distinctuntilchanged;
 
+/**
+ * Compares the arguments of a method annotated with {@link DistinctUntilChanged}
+ */
 public interface DistinctComparator {
 
-    boolean isEqual(final Object[] newParameters);
+    /**
+     * Checks if the arguments of a method call have changed compare to the last call of the
+     * method. This method returns {@link false} when calling it for the first time. It's the
+     * initialization step allowing comparisons with the next arguments.
+     *
+     * @param newParameters arguments of the current method call. Compare them to the last call
+     *                      of {@link #compareWith(Object[])}
+     * @return {@code false} if the arguments have changed compared to the last call of this
+     * method, {@code true} when they are the same
+     */
+    boolean compareWith(final Object[] newParameters);
 }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChanged.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChanged.java
@@ -25,13 +25,16 @@ import java.lang.annotation.Target;
 
 /**
  * When added to a {@code void} method with at least one parameter inside a {@link TiView}, the
- * method implementation will only be called when the parameters change. The {@link
- * Object#hashCode()} method is used to detect changes.
+ * method implementation will only be called when the parameters change. A
+ * {@link DistinctComparator} class is used to detect changes. By default it uses
+ * {@link HashComparator}.
  */
 @Documented
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DistinctUntilChanged {
+
+    Class<? extends DistinctComparator> comparator() default HashComparator.class;
 
     boolean logDropped() default false;
 

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChanged.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChanged.java
@@ -27,14 +27,14 @@ import java.lang.annotation.Target;
  * When added to a {@code void} method with at least one parameter inside a {@link TiView}, the
  * method implementation will only be called when the parameters change. A
  * {@link DistinctComparator} class is used to detect changes. By default it uses
- * {@link HashComparator}.
+ * {@link EqualsComparator}.
  */
 @Documented
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DistinctUntilChanged {
 
-    Class<? extends DistinctComparator> comparator() default HashComparator.class;
+    Class<? extends DistinctComparator> comparator() default EqualsComparator.class;
 
     boolean logDropped() default false;
 

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandler.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandler.java
@@ -33,11 +33,11 @@ final class DistinctUntilChangedInvocationHandler<V> extends AbstractInvocationH
 
     private final V mView;
 
-    DistinctUntilChangedInvocationHandler(V view) {
+    public DistinctUntilChangedInvocationHandler(V view) {
         mView = view;
     }
 
-    void clearCache() {
+    public void clearCache() {
         mLatestMethodCalls.clear();
     }
 

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandler.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandler.java
@@ -19,6 +19,8 @@ import net.grandcentrix.thirtyinch.TiLog;
 import net.grandcentrix.thirtyinch.TiView;
 import net.grandcentrix.thirtyinch.util.AbstractInvocationHandler;
 
+import android.support.annotation.VisibleForTesting;
+
 import java.lang.ref.WeakReference;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -29,7 +31,8 @@ final class DistinctUntilChangedInvocationHandler<V> extends AbstractInvocationH
 
     private static final String TAG = DistinctUntilChangedInvocationHandler.class.getSimpleName();
 
-    private HashMap<String, WeakReference<Object[]>> mLatestMethodCalls = new HashMap<>();
+    @VisibleForTesting
+    HashMap<String, WeakReference<Object[]>> mLatestMethodCalls = new HashMap<>();
 
     private final V mView;
 

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandler.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandler.java
@@ -28,15 +28,15 @@ final class DistinctUntilChangedInvocationHandler<V> extends AbstractInvocationH
 
     private static final String TAG = DistinctUntilChangedInvocationHandler.class.getSimpleName();
 
-    private HashMap<String, Integer> mLatestMethodCalls = new HashMap<>();
+    private HashMap<String, Object[]> mLatestMethodCalls = new HashMap<>();
 
     private final V mView;
 
-    public DistinctUntilChangedInvocationHandler(V view) {
+    DistinctUntilChangedInvocationHandler(V view) {
         mView = view;
     }
 
-    public void clearCache() {
+    void clearCache() {
         mLatestMethodCalls.clear();
     }
 
@@ -82,20 +82,19 @@ final class DistinctUntilChangedInvocationHandler<V> extends AbstractInvocationH
             }
 
             final String methodName = method.toGenericString();
-            final int hashNow = Arrays.hashCode(args);
 
             if (!mLatestMethodCalls.containsKey(methodName)) {
                 // first call to method
                 Object result = method.invoke(mView, args);
-                mLatestMethodCalls.put(methodName, hashNow);
+                mLatestMethodCalls.put(methodName, args);
                 return result;
             }
 
-            final Integer hashBefore = mLatestMethodCalls.get(methodName);
-            if (hashBefore != hashNow) {
+            final Object[] argsBefore = mLatestMethodCalls.get(methodName);
+            if (!Arrays.equals(argsBefore, args)) {
                 // arguments changed, call the method
                 Object result = method.invoke(mView, args);
-                mLatestMethodCalls.put(methodName, hashNow);
+                mLatestMethodCalls.put(methodName, args);
                 return result;
             } else {
                 // don't call the method, the exact same data was already sent to the view

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandler.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandler.java
@@ -87,14 +87,15 @@ final class DistinctUntilChangedInvocationHandler<V> extends AbstractInvocationH
 
             final String methodName = method.toGenericString();
 
-            if (!mLatestMethodCalls.containsKey(methodName)) {
+            final WeakReference<Object[]> lastCallRef = mLatestMethodCalls.get(methodName);
+            if (lastCallRef == null) {
                 // first call to method
                 Object result = method.invoke(mView, args);
                 mLatestMethodCalls.put(methodName, new WeakReference<>(args));
                 return result;
             }
 
-            final Object[] argsBefore = mLatestMethodCalls.get(methodName).get();
+            final Object[] argsBefore = lastCallRef.get();
             if (argsBefore == null || !Arrays.equals(argsBefore, args)) {
                 // arguments changed, call the method
                 Object result = method.invoke(mView, args);

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandler.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandler.java
@@ -123,11 +123,10 @@ final class DistinctUntilChangedInvocationHandler<V> extends AbstractInvocationH
             }
 
         } catch (InvocationTargetException e) {
-            e.getCause().printStackTrace();
-            return null;
-        } catch (IllegalAccessException e) {
             e.printStackTrace();
-            return null;
+            throw e.getCause();
+        } catch (IllegalAccessException e) {
+            throw e;
         }
     }
 }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/EqualsComparator.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/EqualsComparator.java
@@ -1,0 +1,22 @@
+package net.grandcentrix.thirtyinch.distinctuntilchanged;
+
+import java.lang.ref.WeakReference;
+import java.util.Arrays;
+
+/**
+ * {@link DistinctComparator} implementation which uses the {@link Object#equals(Object)} Method
+ * of the parameters to detect changes.
+ */
+public class EqualsComparator implements DistinctComparator {
+
+    private WeakReference<Object[]> mLastParameters;
+
+    @Override
+    public boolean isEqual(final Object[] newParameters) {
+        if (mLastParameters == null || !Arrays.equals(newParameters, mLastParameters.get())) {
+            mLastParameters = new WeakReference<>(newParameters);
+            return false;
+        }
+        return true;
+    }
+}

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/EqualsComparator.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/EqualsComparator.java
@@ -1,21 +1,39 @@
+/*
+ * Copyright (C) 2016 grandcentrix GmbH
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.grandcentrix.thirtyinch.distinctuntilchanged;
 
-import java.lang.ref.WeakReference;
 import java.util.Arrays;
 
 /**
- * {@link DistinctComparator} implementation which uses the {@link Object#equals(Object)} Method
- * of the parameters to detect changes. This is the default implementation used by the
- * {@link DistinctUntilChanged} annotation.
+ * A {@link DistinctComparator} implementation which uses the {@link Object#equals(Object)}
+ * method of the parameters to detect changes. It holds a strong reference to the previously use
+ * parameters for a real {@link Object#equals(Object)} comparison.
+ * <p>
+ * The strong reference to the previous parameters could cause problems when dealing with big
+ * data blobs such as bitmaps. Consider using a simpler comparator like {@link HashComparator} or
+ * {@link WeakEqualsComparator}.
  */
 public class EqualsComparator implements DistinctComparator {
 
-    private WeakReference<Object[]> mLastParameters;
+    private Object[] mLastParameters;
 
     @Override
-    public boolean isEqual(final Object[] newParameters) {
-        if (mLastParameters == null || !Arrays.equals(newParameters, mLastParameters.get())) {
-            mLastParameters = new WeakReference<>(newParameters);
+    public boolean compareWith(final Object[] newParameters) {
+        if (!Arrays.equals(newParameters, mLastParameters)) {
+            mLastParameters = newParameters;
             return false;
         }
         return true;

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/EqualsComparator.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/EqualsComparator.java
@@ -5,7 +5,8 @@ import java.util.Arrays;
 
 /**
  * {@link DistinctComparator} implementation which uses the {@link Object#equals(Object)} Method
- * of the parameters to detect changes.
+ * of the parameters to detect changes. This is the default implementation used by the
+ * {@link DistinctUntilChanged} annotation.
  */
 public class EqualsComparator implements DistinctComparator {
 

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/HashComparator.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/HashComparator.java
@@ -4,8 +4,7 @@ import java.util.Arrays;
 
 /**
  * {@link DistinctComparator} implementation which uses the {@link Object#hashCode()} of the
- * parameters to detect changes. This is the default implementation used by the
- * {@link DistinctUntilChanged} annotation.
+ * parameters to detect changes.
  */
 public class HashComparator implements DistinctComparator {
 

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/HashComparator.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/HashComparator.java
@@ -1,0 +1,23 @@
+package net.grandcentrix.thirtyinch.distinctuntilchanged;
+
+import java.util.Arrays;
+
+/**
+ * {@link DistinctComparator} implementation which uses the {@link Object#hashCode()} of the
+ * parameters to detect changes. This is the default implementation used by the
+ * {@link DistinctUntilChanged} annotation.
+ */
+public class HashComparator implements DistinctComparator {
+
+    private int mLastParametersHash = 0;
+
+    @Override
+    public boolean isEqual(final Object[] newParameters) {
+        final int hash = Arrays.hashCode(newParameters);
+        if (hash == mLastParametersHash) {
+            return true;
+        }
+        mLastParametersHash = hash;
+        return false;
+    }
+}

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/WeakEqualsComparator.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/WeakEqualsComparator.java
@@ -15,25 +15,24 @@
 
 package net.grandcentrix.thirtyinch.distinctuntilchanged;
 
+import java.lang.ref.WeakReference;
 import java.util.Arrays;
 
 /**
- * A {@link DistinctComparator} implementation which uses the {@link Object#hashCode()} of the
- * parameters to detect changes. It doesn't hold a references to the previously sent parameters.
- * In theory this comparison could miss changes compared to {@link EqualsComparator} when multiple
- * mutated object accidentally return the same hashcode.
+ * A {@link DistinctComparator} implementation which uses the {@link Object#equals(Object)}
+ * method of the parameters to detect changes. This comparator holds weak references to the
+ * previous parameters compared to {@link EqualsComparator}
  */
-public class HashComparator implements DistinctComparator {
+public class WeakEqualsComparator implements DistinctComparator {
 
-    private int mLastParametersHash = 0;
+    private WeakReference<Object[]> mLastParameters;
 
     @Override
     public boolean compareWith(final Object[] newParameters) {
-        final int hash = Arrays.hashCode(newParameters);
-        if (hash == mLastParametersHash) {
-            return true;
+        if (mLastParameters == null || !Arrays.equals(newParameters, mLastParameters.get())) {
+            mLastParameters = new WeakReference<>(newParameters);
+            return false;
         }
-        mLastParametersHash = hash;
-        return false;
+        return true;
     }
 }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/WeakEqualsComparator.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/WeakEqualsComparator.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
  */
 public class WeakEqualsComparator implements DistinctComparator {
 
-    private WeakReference<Object[]> mLastParameters;
+    WeakReference<Object[]> mLastParameters;
 
     @Override
     public boolean compareWith(final Object[] newParameters) {

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/WeakEqualsComparator.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/WeakEqualsComparator.java
@@ -15,6 +15,8 @@
 
 package net.grandcentrix.thirtyinch.distinctuntilchanged;
 
+import android.support.annotation.VisibleForTesting;
+
 import java.lang.ref.WeakReference;
 import java.util.Arrays;
 
@@ -25,6 +27,7 @@ import java.util.Arrays;
  */
 public class WeakEqualsComparator implements DistinctComparator {
 
+    @VisibleForTesting
     WeakReference<Object[]> mLastParameters;
 
     @Override

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandlerTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandlerTest.java
@@ -13,21 +13,21 @@ public class DistinctUntilChangedInvocationHandlerTest {
 
     private static class TestView implements TiView {
         int callCount;
+
         @DistinctUntilChanged
         public void ducMethod(String param) {
             callCount++;
         }
     }
 
-    TestView ducView;
-    DistinctUntilChangedInvocationHandler<TestView> handler;
+    private TestView ducView;
+    private DistinctUntilChangedInvocationHandler<TestView> handler;
 
     @Before
     public void setUp() {
         ducView = new TestView();
         handler = new DistinctUntilChangedInvocationHandler<>(ducView);
     }
-
 
     @Test
     public void shouldCallMethodTwice() throws Throwable {
@@ -43,7 +43,6 @@ public class DistinctUntilChangedInvocationHandlerTest {
         assertEquals(2, ducView.callCount);
     }
 
-
     @Test
     public void shouldCallMethodOnce() throws Throwable {
         //given
@@ -55,6 +54,27 @@ public class DistinctUntilChangedInvocationHandlerTest {
 
         //then
         assertEquals(1, ducView.callCount);
+    }
+
+
+    @Test
+    public void shouldCallMethodAfterReferenceIsDropped() throws Throwable {
+        //given
+        Method method = ducView.getClass().getMethod("ducMethod", String.class);
+        Object[] args = new Object[]{"p1"};
+
+
+        //when
+        handler.handleInvocation(null, method, args);
+        handler.handleInvocation(null, method, args);
+        //noinspection UnusedAssignment
+        args = null;
+        //try to clear references
+        System.gc();
+        handler.handleInvocation(null, method, new Object[]{"new param"});
+
+        //then
+        assertEquals(2, ducView.callCount);
     }
 
 }

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandlerTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandlerTest.java
@@ -63,16 +63,15 @@ public class DistinctUntilChangedInvocationHandlerTest {
         Method method = ducView.getClass().getMethod("ducMethod", String.class);
         Object[] args = new Object[]{"p1"};
 
-
         //when
         handler.handleInvocation(null, method, args);
         handler.handleInvocation(null, method, args);
-        //noinspection UnusedAssignment
-        args = null;
-        //try to clear references
-        System.gc();
-        handler.clearCache();
+        assertEquals(1, ducView.callCount);
 
+        //simulate reference dropped
+        handler.mLatestMethodCalls.put("ducMethod", null);
+
+        // should be called again
         handler.handleInvocation(null, method, new Object[]{"new param"});
 
         //then

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandlerTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandlerTest.java
@@ -7,21 +7,139 @@ import org.junit.Test;
 
 import java.lang.reflect.Method;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class DistinctUntilChangedInvocationHandlerTest {
 
-    private static class TestView implements TiView {
+    public static class BadComparator implements DistinctComparator {
+
+        @Override
+        public boolean compareWith(final Object[] newParameters) {
+            // returns true for initial state, should throw
+            return true;
+        }
+    }
+
+    private static class TestView extends NotTiView implements TiView {
+
         int callCount;
+
+        int zeroArgsCount;
+
+        private int notAnnotated;
+
+        private int success;
+
+        @DistinctUntilChanged(comparator = BadComparator.class)
+        public void badComparator(String param) {
+
+        }
 
         @DistinctUntilChanged
         public void ducMethod(String param) {
             callCount++;
         }
+
+        @DistinctUntilChanged(logDropped = true)
+        public void logDropped(String param) {
+            callCount++;
+        }
+
+        public void notAnnotated(String param) {
+            notAnnotated++;
+        }
+
+        public String returnValueOneArg(String param) {
+            return "success" + (++success);
+        }
+
+        public void throwing(final String s) {
+            throw new IllegalStateException(s);
+        }
+
+        public void zeroArgs() {
+            zeroArgsCount++;
+        }
+
+        private void privateMethod() {
+
+        }
+    }
+
+    private static class NotTiView {
+
+        int something;
+
+        // super implementation of TiView should be called directly
+        public void doSomething(String param) {
+            something++;
+        }
     }
 
     private TestView ducView;
+
     private DistinctUntilChangedInvocationHandler<TestView> handler;
+
+    @Test
+    public void callNonTiViewMethods() throws Throwable {
+
+        assertThat(ducView.something).isEqualTo(0);
+        final Method method = ducView.getClass().getMethod("doSomething", String.class);
+        handler.handleInvocation(null, method, new Object[]{"test"});
+        assertThat(ducView.something).isEqualTo(1);
+        handler.handleInvocation(null, method, new Object[]{"test"});
+        assertThat(ducView.something).isEqualTo(2);
+    }
+
+    @Test
+    public void directlyCallNonVoid() throws Throwable {
+        final Method method = ducView.getClass().getMethod("returnValueOneArg", String.class);
+        assertThat(handler.handleInvocation(null, method, new Object[]{"test"}))
+                .isEqualTo("success1");
+        assertThat(handler.handleInvocation(null, method, new Object[]{"test"}))
+                .isEqualTo("success2");
+    }
+
+    @Test
+    public void directlyCallNotAnnotatedMethods() throws Throwable {
+        assertThat(ducView.notAnnotated).isEqualTo(0);
+        final Method method = ducView.getClass().getMethod("notAnnotated", String.class);
+        handler.handleInvocation(null, method, new Object[]{"hi"});
+        assertThat(ducView.notAnnotated).isEqualTo(1);
+        handler.handleInvocation(null, method, new Object[]{"hi"});
+        assertThat(ducView.notAnnotated).isEqualTo(2);
+    }
+
+    @Test
+    public void directlyCallObjectMethods() throws Throwable {
+        final Method method = ducView.getClass().getMethod("toString");
+        assertThat((String) handler.handleInvocation(null, method, new Object[]{}))
+                .contains(TestView.class.getSimpleName());
+    }
+
+    @Test
+    public void directlyForwardCallsWithZeroArguments() throws Throwable {
+        assertThat(ducView.zeroArgsCount).isEqualTo(0);
+        final Method method = ducView.getClass().getMethod("zeroArgs");
+        handler.handleInvocation(null, method, new Object[]{});
+        assertThat(ducView.zeroArgsCount).isEqualTo(1);
+        handler.handleInvocation(null, method, new Object[]{});
+        assertThat(ducView.zeroArgsCount).isEqualTo(2);
+    }
+
+    @Test
+    public void methodsForwardExceptions() throws Throwable {
+        final Method method = ducView.getClass().getMethod("throwing", String.class);
+
+        try {
+            handler.handleInvocation(null, method, new Object[]{"Blubb123"});
+            fail("did not throw");
+        } catch (IllegalStateException e) {
+            assertThat(e).hasMessage("Blubb123");
+        }
+    }
 
     @Before
     public void setUp() {
@@ -30,37 +148,9 @@ public class DistinctUntilChangedInvocationHandlerTest {
     }
 
     @Test
-    public void shouldCallMethodTwice() throws Throwable {
+    public void shouldCallMethodAfterClearCache() throws Throwable {
         //given
-        Method method = ducView.getClass().getMethod("ducMethod", String.class);
-
-        //when
-        handler.handleInvocation(null, method, new Object[]{"test string 1"});
-        handler.handleInvocation(null, method, new Object[]{"test string 2"});
-        handler.handleInvocation(null, method, new Object[]{"test string 2"});
-
-        //then
-        assertEquals(2, ducView.callCount);
-    }
-
-    @Test
-    public void shouldCallMethodOnce() throws Throwable {
-        //given
-        Method method = ducView.getClass().getMethod("ducMethod", String.class);
-
-        //when
-        handler.handleInvocation(null, method, new Object[]{"test string 1"});
-        handler.handleInvocation(null, method, new Object[]{"test string 1"});
-
-        //then
-        assertEquals(1, ducView.callCount);
-    }
-
-
-    @Test
-    public void shouldCallMethodAfterReferenceIsDropped() throws Throwable {
-        //given
-        Method method = ducView.getClass().getMethod("ducMethod", String.class);
+        final Method method = ducView.getClass().getMethod("ducMethod", String.class);
         Object[] args = new Object[]{"p1"};
 
         //when
@@ -69,7 +159,7 @@ public class DistinctUntilChangedInvocationHandlerTest {
         assertEquals(1, ducView.callCount);
 
         //simulate reference dropped
-        handler.mLatestMethodCalls.put("ducMethod", null);
+        handler.clearCache();
 
         // should be called again
         handler.handleInvocation(null, method, new Object[]{"new param"});
@@ -78,4 +168,55 @@ public class DistinctUntilChangedInvocationHandlerTest {
         assertEquals(2, ducView.callCount);
     }
 
+    @Test
+    public void shouldCallMethodOnce() throws Throwable {
+        //given
+        final Method method = ducView.getClass().getMethod("ducMethod", String.class);
+
+        //when
+        handler.handleInvocation(null, method, new Object[]{"test string 1"});
+        handler.handleInvocation(null, method, new Object[]{"test string 1"});
+
+        //then
+        assertEquals(1, ducView.callCount);
+    }
+
+    @Test
+    public void shouldCallMethodTwice() throws Throwable {
+        //given
+        final Method method = ducView.getClass().getMethod("ducMethod", String.class);
+
+        //when
+        handler.handleInvocation(null, method, new Object[]{"test string 1"});
+        handler.handleInvocation(null, method, new Object[]{"test string 2"});
+        handler.handleInvocation(null, method, new Object[]{"test string 2"});
+
+        //then
+        assertEquals(2, ducView.callCount);
+    }
+
+    @Test
+    public void swallowCall() throws Throwable {
+        final Method method = ducView.getClass().getMethod("logDropped", String.class);
+
+        assertEquals(0, ducView.callCount);
+        handler.handleInvocation(null, method, new Object[]{"test string"});
+        assertEquals(1, ducView.callCount);
+
+        handler.handleInvocation(null, method, new Object[]{"test string"});
+        assertEquals(1, ducView.callCount);
+    }
+
+    @Test
+    public void throwWhenInitializingABadComparator() throws Throwable {
+        final Method method = ducView.getClass().getMethod("badComparator", String.class);
+
+        try {
+            handler.handleInvocation(null, method, new Object[]{"test"});
+            fail("did not throw");
+        } catch (IllegalStateException e) {
+            assertThat(e).hasMessageContaining("true")
+                    .hasMessageContaining("initialization");
+        }
+    }
 }

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandlerTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandlerTest.java
@@ -71,6 +71,8 @@ public class DistinctUntilChangedInvocationHandlerTest {
         args = null;
         //try to clear references
         System.gc();
+        handler.clearCache();
+
         handler.handleInvocation(null, method, new Object[]{"new param"});
 
         //then

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandlerTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandlerTest.java
@@ -1,0 +1,60 @@
+package net.grandcentrix.thirtyinch.distinctuntilchanged;
+
+import net.grandcentrix.thirtyinch.TiView;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertEquals;
+
+public class DistinctUntilChangedInvocationHandlerTest {
+
+    private static class TestView implements TiView {
+        int callCount;
+        @DistinctUntilChanged
+        public void ducMethod(String param) {
+            callCount++;
+        }
+    }
+
+    TestView ducView;
+    DistinctUntilChangedInvocationHandler<TestView> handler;
+
+    @Before
+    public void setUp() {
+        ducView = new TestView();
+        handler = new DistinctUntilChangedInvocationHandler<>(ducView);
+    }
+
+
+    @Test
+    public void shouldCallMethodTwice() throws Throwable {
+        //given
+        Method method = ducView.getClass().getMethod("ducMethod", String.class);
+
+        //when
+        handler.handleInvocation(null, method, new Object[]{"test string 1"});
+        handler.handleInvocation(null, method, new Object[]{"test string 2"});
+        handler.handleInvocation(null, method, new Object[]{"test string 2"});
+
+        //then
+        assertEquals(2, ducView.callCount);
+    }
+
+
+    @Test
+    public void shouldCallMethodOnce() throws Throwable {
+        //given
+        Method method = ducView.getClass().getMethod("ducMethod", String.class);
+
+        //when
+        handler.handleInvocation(null, method, new Object[]{"test string 1"});
+        handler.handleInvocation(null, method, new Object[]{"test string 1"});
+
+        //then
+        assertEquals(1, ducView.callCount);
+    }
+
+}

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedTest.java
@@ -1,0 +1,194 @@
+package net.grandcentrix.thirtyinch.distinctuntilchanged;
+
+import net.grandcentrix.thirtyinch.TiView;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+/**
+ * Testing {@link DistinctUntilChanged} annotation via {@link DistinctUntilChangedInterceptor}
+ * requires interfaces extending {@link TiView}.
+ */
+public class DistinctUntilChangedTest {
+
+    private class CountWrapper {
+
+        private int mCalled = 0;
+
+        public void call() {
+            mCalled++;
+        }
+
+        public int getCalled() {
+            return mCalled;
+        }
+    }
+
+    /**
+     * This class doesn't have a good hashcode method
+     */
+    private class BadHashObject {
+
+        private final String mTest;
+
+        public BadHashObject(final String test) {
+            mTest = test;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            final BadHashObject that = (BadHashObject) o;
+
+            return mTest != null ? mTest.equals(that.mTest) : that.mTest == null;
+
+        }
+
+        @Override
+        public int hashCode() {
+            return 42;
+        }
+    }
+
+    /**
+     * This class doesn't have a good equals method
+     */
+    private class BadEqualsObject {
+
+        private final String mTest;
+
+        public BadEqualsObject(final String test) {
+            mTest = test;
+        }
+
+        @Override
+        public int hashCode() {
+            return mTest != null ? mTest.hashCode() : 0;
+        }
+    }
+
+    private interface TestViewHash extends TiView {
+
+        @DistinctUntilChanged(comparator = HashComparator.class)
+        void annotatedMethod(String str);
+    }
+
+    private interface TestViewEquals extends TiView {
+
+        @DistinctUntilChanged(comparator = EqualsComparator.class)
+        void annotatedMethod(String str);
+    }
+
+    private interface TestViewBadHash extends TiView {
+
+        @DistinctUntilChanged(comparator = EqualsComparator.class)
+        void annotatedMethod(BadHashObject bho);
+    }
+
+    private interface TestViewBadEquals extends TiView {
+
+        @DistinctUntilChanged(comparator = HashComparator.class)
+        void annotatedMethod(BadEqualsObject bho);
+    }
+
+    /**
+     * Using {@link HashComparator} when the objects have a bad equals method works.
+     */
+    @Test
+    public void testDistincUntilChangedBadEquals() throws Exception {
+        DistinctUntilChangedInterceptor interceptor = new DistinctUntilChangedInterceptor();
+        final CountWrapper counter = new CountWrapper();
+        final TestViewBadEquals testView = new TestViewBadEquals() {
+
+            @Override
+            public void annotatedMethod(final BadEqualsObject beo) {
+                counter.call();
+            }
+        };
+        final TestViewBadEquals testViewWrapped = interceptor.intercept(testView);
+
+        testViewWrapped.annotatedMethod(new BadEqualsObject("test"));
+        testViewWrapped.annotatedMethod(new BadEqualsObject("test"));
+        testViewWrapped.annotatedMethod(new BadEqualsObject("test2"));
+
+        assertThat(counter.getCalled(), is(equalTo(2)));
+    }
+
+    /**
+     * Using {@link EqualsComparator} when the objects have a bad hashcode method works.
+     */
+    @Test
+    public void testDistincUntilChangedBadHash() throws Exception {
+        DistinctUntilChangedInterceptor interceptor = new DistinctUntilChangedInterceptor();
+        final CountWrapper counter = new CountWrapper();
+        final TestViewBadHash testView = new TestViewBadHash() {
+
+            @Override
+            public void annotatedMethod(final BadHashObject bho) {
+                counter.call();
+            }
+        };
+        final TestViewBadHash testViewWrapped = interceptor.intercept(testView);
+
+        testViewWrapped.annotatedMethod(new BadHashObject("test"));
+        testViewWrapped.annotatedMethod(new BadHashObject("test"));
+        testViewWrapped.annotatedMethod(new BadHashObject("test2"));
+
+        assertThat(counter.getCalled(), is(equalTo(2)));
+    }
+
+    /**
+     * Using {@link EqualsComparator} should work on well defined objects.
+     */
+    @Test
+    public void testDistincUntilChangedEquals() throws Exception {
+        DistinctUntilChangedInterceptor interceptor = new DistinctUntilChangedInterceptor();
+        final CountWrapper counter = new CountWrapper();
+        final TestViewEquals testView = new TestViewEquals() {
+
+            @Override
+            public void annotatedMethod(final String str) {
+                counter.call();
+            }
+        };
+        final TestViewEquals testViewWrapped = interceptor.intercept(testView);
+
+        testViewWrapped.annotatedMethod("test");
+        testViewWrapped.annotatedMethod("test");
+        testViewWrapped.annotatedMethod("test2");
+
+        assertThat(counter.getCalled(), is(equalTo(2)));
+    }
+
+    /**
+     * Using {@link HashComparator} should work on well defined objects.
+     */
+    @Test
+    public void testDistincUntilChangedHash() throws Exception {
+        DistinctUntilChangedInterceptor interceptor = new DistinctUntilChangedInterceptor();
+        final CountWrapper counter = new CountWrapper();
+        final TestViewHash testView = new TestViewHash() {
+
+            @Override
+            public void annotatedMethod(final String str) {
+                counter.call();
+            }
+        };
+        final TestViewHash testViewWrapped = interceptor.intercept(testView);
+
+        testViewWrapped.annotatedMethod("test");
+        testViewWrapped.annotatedMethod("test");
+        testViewWrapped.annotatedMethod("test2");
+
+        assertThat(counter.getCalled(), is(equalTo(2)));
+    }
+}

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/EqualsComparatorTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/EqualsComparatorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2016 grandcentrix GmbH
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.grandcentrix.thirtyinch.distinctuntilchanged;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EqualsComparatorTest {
+
+    @Test
+    public void different() throws Exception {
+        final EqualsComparator comparator = new EqualsComparator();
+        assertFalse(comparator.compareWith(new Object[]{"arg1"}));
+        assertFalse(comparator.compareWith(new Object[]{"arg2"}));
+    }
+
+    @Test
+    public void initialize() throws Exception {
+
+        final EqualsComparator comparator = new EqualsComparator();
+        assertFalse(comparator.compareWith(new Object[]{"arg1"}));
+    }
+
+    @Test
+    public void same() throws Exception {
+        final EqualsComparator comparator = new EqualsComparator();
+
+        assertFalse(comparator.compareWith(new Object[]{"arg1"}));
+        assertTrue(comparator.compareWith(new Object[]{"arg1"}));
+        assertTrue(comparator.compareWith(new Object[]{"arg1"}));
+
+    }
+
+    @Test
+    public void sameEquals_differentHashcode() throws Exception {
+        final EqualsComparator comparator = new EqualsComparator();
+        final Object arg1 = new Object() {
+            @Override
+            public boolean equals(final Object obj) {
+                return true;
+            }
+        };
+        final Object arg2 = new Object() {
+            @Override
+            public boolean equals(final Object obj) {
+                return true;
+            }
+        };
+        // equal but not same hash code
+        assertThat(arg1).isEqualTo(arg2);
+        assertThat(arg1.hashCode()).isNotEqualTo(arg2.hashCode());
+
+        assertThat(comparator.compareWith(new Object[]{arg1})).isFalse();
+        assertThat(comparator.compareWith(new Object[]{arg2})).isTrue();
+        assertThat(comparator.compareWith(new Object[]{arg1})).isTrue();
+        assertThat(comparator.compareWith(new Object[]{arg2})).isTrue();
+    }
+
+    @Test
+    public void sameObject_equalsFalse_sameHashcode() throws Exception {
+
+        final EqualsComparator comparator = new EqualsComparator();
+        final Object arg1 = new Object() {
+            @Override
+            public boolean equals(final Object obj) {
+                return false;
+            }
+
+            @Override
+            public int hashCode() {
+                return 1;
+            }
+        };
+        // equal but not same hash code
+        assertThat(arg1).isNotEqualTo(arg1);
+        assertThat(arg1).isSameAs(arg1);
+
+        assertThat(comparator.compareWith(new Object[]{arg1})).isFalse();
+        assertThat(comparator.compareWith(new Object[]{arg1})).isFalse();
+        assertThat(comparator.compareWith(new Object[]{arg1})).isFalse();
+
+    }
+}

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/HashComparatorTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/HashComparatorTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2016 grandcentrix GmbH
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.grandcentrix.thirtyinch.distinctuntilchanged;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HashComparatorTest {
+
+    @Test
+    public void different() throws Exception {
+        final HashComparator comparator = new HashComparator();
+        assertFalse(comparator.compareWith(new Object[]{"arg1"}));
+        assertFalse(comparator.compareWith(new Object[]{"arg2"}));
+    }
+
+    @Test
+    public void initialize() throws Exception {
+
+        final HashComparator comparator = new HashComparator();
+        assertFalse(comparator.compareWith(new Object[]{"arg1"}));
+    }
+
+    @Test
+    public void same() throws Exception {
+        final HashComparator comparator = new HashComparator();
+
+        assertFalse(comparator.compareWith(new Object[]{"arg1"}));
+        assertTrue(comparator.compareWith(new Object[]{"arg1"}));
+        assertTrue(comparator.compareWith(new Object[]{"arg1"}));
+    }
+
+    @Test
+    public void sameHashcode_differentEquals() throws Exception {
+        final HashComparator comparator = new HashComparator();
+        final Object arg1 = new Object() {
+            @Override
+            public boolean equals(final Object obj) {
+                return false;
+            }
+
+            @Override
+            public int hashCode() {
+                return 1;
+            }
+        };
+        final Object arg2 = new Object() {
+            @Override
+            public boolean equals(final Object obj) {
+                return false;
+            }
+
+            @Override
+            public int hashCode() {
+                return 1;
+            }
+        };
+        // equal but not same hash code
+        assertThat(arg1).isNotEqualTo(arg2);
+        assertThat(arg1).isNotSameAs(arg2);
+        assertThat(arg1.hashCode()).isEqualTo(arg2.hashCode());
+
+        assertThat(comparator.compareWith(new Object[]{arg1})).isFalse();
+        assertThat(comparator.compareWith(new Object[]{arg2})).isTrue();
+        assertThat(comparator.compareWith(new Object[]{arg1})).isTrue();
+        assertThat(comparator.compareWith(new Object[]{arg2})).isTrue();
+    }
+}

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/WeakEqualsComparatorTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/WeakEqualsComparatorTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2016 grandcentrix GmbH
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.grandcentrix.thirtyinch.distinctuntilchanged;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WeakEqualsComparatorTest {
+
+    @Test
+    public void different() throws Exception {
+        final WeakEqualsComparator comparator = new WeakEqualsComparator();
+        assertFalse(comparator.compareWith(new Object[]{"arg1"}));
+        assertFalse(comparator.compareWith(new Object[]{"arg2"}));
+    }
+
+    @Test
+    public void gcClearedReferences() throws Exception {
+
+        final WeakEqualsComparator comparator = new WeakEqualsComparator();
+
+        final Object arg = new Object();
+
+        assertFalse(comparator.compareWith(new Object[]{arg}));
+        assertTrue(comparator.compareWith(new Object[]{arg}));
+
+        // simulate drop of reference
+        comparator.mLastParameters.clear();
+
+        assertFalse(comparator.compareWith(new Object[]{arg}));
+    }
+
+    @Test
+    public void initialize() throws Exception {
+
+        final WeakEqualsComparator comparator = new WeakEqualsComparator();
+        assertFalse(comparator.compareWith(new Object[]{"arg1"}));
+    }
+
+    @Test
+    public void same() throws Exception {
+        final WeakEqualsComparator comparator = new WeakEqualsComparator();
+
+        assertFalse(comparator.compareWith(new Object[]{"arg1"}));
+        assertTrue(comparator.compareWith(new Object[]{"arg1"}));
+        assertTrue(comparator.compareWith(new Object[]{"arg1"}));
+
+    }
+
+    @Test
+    public void sameEquals_differentHashcode() throws Exception {
+        final WeakEqualsComparator comparator = new WeakEqualsComparator();
+        final Object arg1 = new Object() {
+            @Override
+            public boolean equals(final Object obj) {
+                return true;
+            }
+        };
+        final Object arg2 = new Object() {
+            @Override
+            public boolean equals(final Object obj) {
+                return true;
+            }
+        };
+        // equal but not same hash code
+        assertThat(arg1).isEqualTo(arg2);
+        assertThat(arg1.hashCode()).isNotEqualTo(arg2.hashCode());
+
+        assertThat(comparator.compareWith(new Object[]{arg1})).isFalse();
+        assertThat(comparator.compareWith(new Object[]{arg2})).isTrue();
+        assertThat(comparator.compareWith(new Object[]{arg1})).isTrue();
+        assertThat(comparator.compareWith(new Object[]{arg2})).isTrue();
+    }
+
+    @Test
+    public void sameObject_equalsFalse_sameHashcode() throws Exception {
+
+        final WeakEqualsComparator comparator = new WeakEqualsComparator();
+        final Object arg1 = new Object() {
+            @Override
+            public boolean equals(final Object obj) {
+                return false;
+            }
+
+            @Override
+            public int hashCode() {
+                return 1;
+            }
+        };
+        // equal but not same hash code
+        assertThat(arg1).isNotEqualTo(arg1);
+        assertThat(arg1).isSameAs(arg1);
+
+        assertThat(comparator.compareWith(new Object[]{arg1})).isFalse();
+        assertThat(comparator.compareWith(new Object[]{arg1})).isFalse();
+        assertThat(comparator.compareWith(new Object[]{arg1})).isFalse();
+
+    }
+}


### PR DESCRIPTION
As discussed in #19 the current implementation of `@DistinctUntilChanged` using the `hashCode()` of the arguments could cause problems.

The new default implementation uses `equals()` instead of `hashcode()`. A `DistinctComparator` can be set as argument of the annotation `@DistinctUntilChanged(comparator = EqualsComparator.class)`. Three different implementations exist:
- `EqualsComparator` (default) - uses `equals()` for comparison and holds a strong reference to the previous arguements
- `WeakEqualsComparator` -  uses `equals()` for comparison and holds a weak reference to the previous arguments. Could call a method twice when `gc()` kicks in.
- `HashComparator` - old implementation using `hashCode()` for comparison. Doesn't hold references to the arguments

When writing tests I detected that the `DistinctUntilChangedInvocationHandler` swallows exceptions thrown by the `TiView`. The same problem was already discovered when using the `@CallOnMainThread` annotation 23034a0b98c2ed2a8548b0ed1f7575371188de92. I fixed it here accordingly

These proguard rules are required:

```
# ThirtyInch
-keep class net.grandcentrix.thirtyinch.distinctuntilchanged.**
-keep class net.grandcentrix.thirtyinch.callonmainthread.**
```
