### PR TITLE
Change onWakeUp() to onAttachView(TiView) and onSleep() to onDetachView()

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ public interface HelloWorldView extends TiView {
 ```java
 public class HelloWorldPresenter extends TiPresenter<HelloWorldView> {
 
-    @Override
-    protected void onWakeUp() {
-        super.onWakeUp();
+    @Override    
+    protected void onAttachView(@NonNull final HelloWorldView view) {
+        super.onAttachView(view);
         getView().showText("Hello World!");
     }
 }
@@ -113,7 +113,7 @@ It can be `CREATED` and `DESTROYED`.
 The corresponding callbacks `onCreate()` and `onDestroy()` will be only called once!
 
 The `TiView` can either be `ATTACHED` or `DETACHED`.
-The corresponding callbacks are `onWakeUp()` and `onSleep()` which maps to `onStart()` and `onStop()`.
+The corresponding callbacks are `onAttachView(TiView)` and `onDetachView()` which maps to `onStart()` and `onStop()`.
 
 
 ```java
@@ -125,13 +125,13 @@ public class MyPresenter extends TiPresenter<MyView> {
     }
 
     @Override
-    protected void onWakeUp() {
-        super.onWakeUp();
+    protected void onAttachView(@NonNull final HelloWorldView view) {
+        super.onAttachView(view);
     }
 
     @Override
-    protected void onSleep() {
-        super.onSleep();
+    protected void onDetachView() {
+        super.onDetachView();
     }
 
     @Override
@@ -210,7 +210,7 @@ When calling this method the `View` receives no duplicated calls.
 The View swallows the second call when a method gets called with the same (hashcode) parameters twice.
 
 Usecase:
-The Presenter binds a huge list to the `View`. The app loses focus (`onSleep()`) and the exact same Activity instance gains focus again (`onWakeUp()`).
+The Presenter binds a huge list to the `View`. The app loses focus (`onDetachView()`) and the exact same Activity instance gains focus again (`onAttachView(view)`).
 The `Activity` still shows the huge list.
 The `Presenter` binds the huge list again to the `View`.
 When the data has changed the list will be updated.
@@ -266,10 +266,10 @@ public class HelloWorldPresenter extends TiPresenter<HelloWorldView> {
     }
 
     @Override
-    protected void onWakeUp() {
-        super.onWakeUp();
-
-        // automatically unsubscribe in onSleep()
+    protected void onAttachView(@NonNull final HelloWorldView view) {
+        super.onAttachView(view);
+        
+        // automatically unsubscribe in onDetachView(view)
         rxHelper.manageViewSubscription(anotherObservable.subscribe());
     }
 }

--- a/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiActivityPlugin.java
+++ b/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiActivityPlugin.java
@@ -172,7 +172,6 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
 
     @Override
     public void onStart() {
-        mDelegate.onStart_beforeSuper();
         super.onStart();
         mDelegate.onStart_afterSuper();
     }

--- a/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterSubscriptionHandler.java
+++ b/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterSubscriptionHandler.java
@@ -17,6 +17,7 @@ package net.grandcentrix.thirtyinch.rx;
 
 import net.grandcentrix.thirtyinch.TiLifecycleObserver;
 import net.grandcentrix.thirtyinch.TiPresenter;
+import net.grandcentrix.thirtyinch.TiView;
 
 import android.support.annotation.NonNull;
 
@@ -34,7 +35,7 @@ public class RxTiPresenterSubscriptionHandler {
             @Override
             public void onChange(final TiPresenter.State state,
                     final boolean beforeLifecycleEvent) {
-                if (state == TiPresenter.State.CREATED_WITH_DETACHED_VIEW && beforeLifecycleEvent) {
+                if (state == TiPresenter.State.VIEW_DETACHED && beforeLifecycleEvent) {
                     // unsubscribe all UI subscriptions created in wakeUp() and added
                     // via manageViewSubscription(Subscription)
                     if (mUiSubscriptions != null) {
@@ -72,8 +73,8 @@ public class RxTiPresenterSubscriptionHandler {
 
     /**
      * Add your subscriptions for View events to this method to get them automatically cleaned up
-     * in {@link TiPresenter#sleep()}. typically call this in {@link TiPresenter#wakeUp()} where
-     * you subscribe to the UI events.
+     * in {@link TiPresenter#detachView()}. typically call this in {@link
+     * TiPresenter#attachView(TiView)} where you subscribe to the UI events.
      *
      * @throws IllegalStateException when no view is attached
      */

--- a/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterUtils.java
+++ b/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterUtils.java
@@ -18,7 +18,7 @@ package net.grandcentrix.thirtyinch.rx;
 import net.grandcentrix.thirtyinch.Removable;
 import net.grandcentrix.thirtyinch.TiLifecycleObserver;
 import net.grandcentrix.thirtyinch.TiPresenter;
-import net.grandcentrix.thirtyinch.rx.OperatorSemaphore;
+import net.grandcentrix.thirtyinch.TiView;
 
 import rx.Observable;
 import rx.Subscriber;
@@ -111,7 +111,7 @@ public class RxTiPresenterUtils {
 
     /**
      * Observable of the view state. The View is ready to receive calls after calling {@link
-     * TiPresenter#wakeUp()} and before calling {@link TiPresenter#sleep()}.
+     * TiPresenter#attachView(TiView)} and before calling {@link TiPresenter#detachView()}.
      */
     public static Observable<Boolean> isViewReady(final TiPresenter presenter) {
         return Observable.create(
@@ -120,7 +120,7 @@ public class RxTiPresenterUtils {
                     public void call(final Subscriber<? super Boolean> subscriber) {
                         if (!subscriber.isUnsubscribed()) {
                             subscriber.onNext(presenter.getState()
-                                    == TiPresenter.State.VIEW_ATTACHED_AND_AWAKE);
+                                    == TiPresenter.State.VIEW_ATTACHED);
                         }
 
                         final Removable removable = presenter
@@ -130,7 +130,7 @@ public class RxTiPresenterUtils {
                                             final boolean beforeLifecycleEvent) {
                                         if (!subscriber.isUnsubscribed()) {
                                             subscriber.onNext(state
-                                                    == TiPresenter.State.VIEW_ATTACHED_AND_AWAKE);
+                                                    == TiPresenter.State.VIEW_ATTACHED);
                                         }
                                     }
                                 });

--- a/rx/src/test/java/net/grandcentrix/thirtyinch/rx/RxUtilsTest.java
+++ b/rx/src/test/java/net/grandcentrix/thirtyinch/rx/RxUtilsTest.java
@@ -58,18 +58,13 @@ public class RxUtilsTest {
     @Test
     public void testDeliverLatestCacheToViewViewNotReady() throws Exception {
         mPresenter.create();
-        mPresenter.bindNewView(mView);
 
         TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
         Observable.just(1, 2, 3)
                 .compose(RxTiPresenterUtils.<Integer>deliverLatestCacheToView(mPresenter))
                 .subscribe(testSubscriber);
 
-        testSubscriber.assertNotCompleted();
-        testSubscriber.assertNoErrors();
-        testSubscriber.assertNoValues();
-
-        mPresenter.wakeUp();
+        mPresenter.attachView(mView);
 
         testSubscriber.assertNotCompleted();
         testSubscriber.assertNoErrors();
@@ -79,9 +74,8 @@ public class RxUtilsTest {
     @Test
     public void testDeliverLatestCacheToViewViewReady() throws Exception {
         mPresenter.create();
-        mPresenter.bindNewView(mView);
+        mPresenter.attachView(mView);
 
-        mPresenter.wakeUp();
         TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
         Observable.just(1, 2, 3)
                 .compose(RxTiPresenterUtils.<Integer>deliverLatestCacheToView(mPresenter))
@@ -95,18 +89,13 @@ public class RxUtilsTest {
     @Test
     public void testDeliverLatestToViewViewNotReady() throws Exception {
         mPresenter.create();
-        mPresenter.bindNewView(mView);
 
         TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
         Observable.just(1, 2, 3)
                 .compose(RxTiPresenterUtils.<Integer>deliverLatestToView(mPresenter))
                 .subscribe(testSubscriber);
 
-        testSubscriber.assertNotCompleted();
-        testSubscriber.assertNoErrors();
-        testSubscriber.assertNoValues();
-
-        mPresenter.wakeUp();
+        mPresenter.attachView(mView);
 
         testSubscriber.assertCompleted();
         testSubscriber.assertNoErrors();
@@ -116,9 +105,8 @@ public class RxUtilsTest {
     @Test
     public void testDeliverLatestToViewViewReady() throws Exception {
         mPresenter.create();
-        mPresenter.bindNewView(mView);
+        mPresenter.attachView(mView);
 
-        mPresenter.wakeUp();
         TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
         Observable.just(1, 2, 3)
                 .compose(RxTiPresenterUtils.<Integer>deliverLatestToView(mPresenter))
@@ -132,18 +120,12 @@ public class RxUtilsTest {
     @Test
     public void testDeliverToViewViewNotReady() throws Exception {
         mPresenter.create();
-        mPresenter.bindNewView(mView);
+        mPresenter.attachView(mView);
 
         TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
         Observable.just(1, 2, 3)
                 .compose(RxTiPresenterUtils.<Integer>deliverToView(mPresenter))
                 .subscribe(testSubscriber);
-
-        testSubscriber.assertNotCompleted();
-        testSubscriber.assertNoErrors();
-        testSubscriber.assertNoValues();
-
-        mPresenter.wakeUp();
 
         testSubscriber.assertCompleted();
         testSubscriber.assertNoErrors();
@@ -153,9 +135,8 @@ public class RxUtilsTest {
     @Test
     public void testDeliverToViewViewReady() throws Exception {
         mPresenter.create();
-        mPresenter.bindNewView(mView);
+        mPresenter.attachView(mView);
 
-        mPresenter.wakeUp();
         TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
         Observable.just(1, 2, 3)
                 .compose(RxTiPresenterUtils.<Integer>deliverToView(mPresenter))
@@ -206,14 +187,14 @@ public class RxUtilsTest {
     @Test
     public void testManageViewSubscription() throws Exception {
         mPresenter.create();
-        mPresenter.wakeUp();
+        mPresenter.attachView(mock(TiView.class));
         TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
 
         mSubscriptionHandler.manageViewSubscription(testSubscriber);
 
         assertThat(testSubscriber.isUnsubscribed(), equalTo(false));
 
-        mPresenter.sleep();
+        mPresenter.detachView();
 
         testSubscriber.assertUnsubscribed();
     }
@@ -222,29 +203,26 @@ public class RxUtilsTest {
     @Test
     public void testSleep() throws Exception {
         mPresenter.create();
-        mPresenter.bindNewView(mView);
-        mPresenter.wakeUp();
+        mPresenter.attachView(mView);
         TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
 
         mSubscriptionHandler.manageViewSubscription(testSubscriber);
-        mPresenter.sleep();
+        mPresenter.detachView();
 
         testSubscriber.assertUnsubscribed();
         assertThat(mPresenter.getView(), nullValue());
-        assertThat(mPresenter.onSleepCalled, equalTo(1));
+        assertThat(mPresenter.onDetachCalled, equalTo(1));
     }
 
     @Test
     public void testSleepBeforeWakeUp() throws Exception {
         mPresenter.create();
-        mPresenter.bindNewView(mView);
         TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
 
         mSubscriptionHandler.manageViewSubscription(testSubscriber);
-        mPresenter.sleep();
+        mPresenter.detachView();
 
         assertThat(testSubscriber.isUnsubscribed(), equalTo(false));
-        assertThat(mPresenter.getView(), equalTo(mView));
-        assertThat(mPresenter.onSleepCalled, equalTo(0));
+        assertThat(mPresenter.onDetachCalled, equalTo(0));
     }
 }

--- a/rx/src/test/java/net/grandcentrix/thirtyinch/rx/RxUtilsTest.java
+++ b/rx/src/test/java/net/grandcentrix/thirtyinch/rx/RxUtilsTest.java
@@ -201,7 +201,7 @@ public class RxUtilsTest {
 
 
     @Test
-    public void testSleep() throws Exception {
+    public void testDetach() throws Exception {
         mPresenter.create();
         mPresenter.attachView(mView);
         TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
@@ -215,7 +215,7 @@ public class RxUtilsTest {
     }
 
     @Test
-    public void testSleepBeforeWakeUp() throws Exception {
+    public void testDetachBeforeAttach() throws Exception {
         mPresenter.create();
         TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
 

--- a/rx/src/test/java/net/grandcentrix/thirtyinch/rx/TiMockPresenter.java
+++ b/rx/src/test/java/net/grandcentrix/thirtyinch/rx/TiMockPresenter.java
@@ -18,6 +18,8 @@ package net.grandcentrix.thirtyinch.rx;
 import net.grandcentrix.thirtyinch.TiPresenter;
 import net.grandcentrix.thirtyinch.TiView;
 
+import android.support.annotation.NonNull;
+
 /**
  * @author jannisveerkamp
  * @since 11.07.16.
@@ -28,9 +30,9 @@ class TiMockPresenter extends TiPresenter<TiView> {
 
     protected int onDestroyCalled = 0;
 
-    protected int onSleepCalled = 0;
+    protected int onDetachCalled = 0;
 
-    protected int onWakeUpCalled = 0;
+    protected int onAttachCalled = 0;
 
     @Override
     protected void onCreate() {
@@ -45,14 +47,14 @@ class TiMockPresenter extends TiPresenter<TiView> {
     }
 
     @Override
-    protected void onSleep() {
-        super.onSleep();
-        onSleepCalled++;
+    protected void onDetachView() {
+        super.onDetachView();
+        onDetachCalled++;
     }
 
     @Override
-    protected void onWakeUp() {
-        super.onWakeUp();
-        onWakeUpCalled++;
+    protected void onAttachView(@NonNull final TiView view) {
+        super.onAttachView(view);
+        onAttachCalled++;
     }
 }

--- a/sample/src/main/java/net/grandcentrix/thirtyinch/sample/HelloWorldPresenter.java
+++ b/sample/src/main/java/net/grandcentrix/thirtyinch/sample/HelloWorldPresenter.java
@@ -19,6 +19,8 @@ import net.grandcentrix.thirtyinch.TiPresenter;
 import net.grandcentrix.thirtyinch.rx.RxTiPresenterSubscriptionHandler;
 import net.grandcentrix.thirtyinch.rx.RxTiPresenterUtils;
 
+import android.support.annotation.NonNull;
+
 import java.util.concurrent.TimeUnit;
 
 import rx.Observable;
@@ -84,18 +86,18 @@ public class HelloWorldPresenter extends TiPresenter<HelloWorldView> {
     }
 
     @Override
-    protected void onWakeUp() {
-        super.onWakeUp();
+    protected void onAttachView(@NonNull final HelloWorldView view) {
+        super.onAttachView(view);
 
         rxSubscriptionHelper.manageViewSubscription(mText.asObservable()
                 .subscribe(new Action1<String>() {
                     @Override
                     public void call(final String text) {
-                        getView().showText(text);
+                        view.showText(text);
                     }
                 }));
 
-        rxSubscriptionHelper.manageViewSubscription(getView().onButtonClicked()
+        rxSubscriptionHelper.manageViewSubscription(view.onButtonClicked()
                 .subscribe(new Action1<Void>() {
                     @Override
                     public void call(final Void aVoid) {

--- a/sample/src/main/java/net/grandcentrix/thirtyinch/sample/SamplePresenter.java
+++ b/sample/src/main/java/net/grandcentrix/thirtyinch/sample/SamplePresenter.java
@@ -39,6 +39,7 @@ public class SamplePresenter extends TiPresenter<SampleView> {
                 .subscribe(new Action1<Long>() {
                     @Override
                     public void call(final Long alive) {
+                        // deliverLatestToView makes getView() here @NonNull
                         getView().showText("I'm a fragment and alive for " + (alive * 37) + "ms");
                     }
                 }));

--- a/test/src/main/java/net/grandcentrix/thirtyinch/test/TiPresenterInstructor.java
+++ b/test/src/main/java/net/grandcentrix/thirtyinch/test/TiPresenterInstructor.java
@@ -33,8 +33,7 @@ public class TiPresenterInstructor<V extends TiView> {
     public void attachView(final V view) {
         detachView();
 
-        mPresenter.bindNewView(view);
-        mPresenter.wakeUp();
+        mPresenter.attachView(view);
     }
 
     public void create() {
@@ -47,7 +46,7 @@ public class TiPresenterInstructor<V extends TiView> {
     }
 
     /**
-     * moves the presenter into state {@link net.grandcentrix.thirtyinch.TiPresenter.State#CREATED_WITH_DETACHED_VIEW}
+     * moves the presenter into state {@link net.grandcentrix.thirtyinch.TiPresenter.State#VIEW_DETACHED}
      * from every state
      */
     public void detachView() {
@@ -56,11 +55,11 @@ public class TiPresenterInstructor<V extends TiView> {
             case INITIALIZED:
                 mPresenter.create();
                 break;
-            case CREATED_WITH_DETACHED_VIEW:
+            case VIEW_DETACHED:
                 // already there
                 break;
-            case VIEW_ATTACHED_AND_AWAKE:
-                mPresenter.sleep();
+            case VIEW_ATTACHED:
+                mPresenter.detachView();
                 break;
             case DESTROYED:
                 throw new IllegalStateException(

--- a/thirtyinch/src/androidTest/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegateTest.java
+++ b/thirtyinch/src/androidTest/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegateTest.java
@@ -67,7 +67,7 @@ public class TiActivityDelegateTest {
 
         mDelegate.onCreate_afterSuper(null);
 
-        assertEquals(TiPresenter.State.CREATED_WITH_DETACHED_VIEW, mPresenter.getState());
+        assertEquals(TiPresenter.State.VIEW_DETACHED, mPresenter.getState());
 
         mDelegate.onDestroy_afterSuper();
         assertEquals(TiPresenter.State.DESTROYED, mPresenter.getState());
@@ -94,13 +94,13 @@ public class TiActivityDelegateTest {
         mPresenter = firstPresenter;
         mDelegate.onCreate_afterSuper(null);
 
-        assertEquals(TiPresenter.State.CREATED_WITH_DETACHED_VIEW, mPresenter.getState());
+        assertEquals(TiPresenter.State.VIEW_DETACHED, mPresenter.getState());
 
         final Bundle bundle = new Bundle();
         mDelegate.onSaveInstanceState_afterSuper(bundle);
 
         mDelegate.onDestroy_afterSuper();
-        assertEquals(TiPresenter.State.CREATED_WITH_DETACHED_VIEW, mPresenter.getState());
+        assertEquals(TiPresenter.State.VIEW_DETACHED, mPresenter.getState());
 
         mPresenter = secondPresenter;
         mDelegate = newDelegate();
@@ -124,13 +124,13 @@ public class TiActivityDelegateTest {
 
         mDelegate.onCreate_afterSuper(null);
 
-        assertEquals(TiPresenter.State.CREATED_WITH_DETACHED_VIEW, mPresenter.getState());
+        assertEquals(TiPresenter.State.VIEW_DETACHED, mPresenter.getState());
 
         final Bundle bundle = new Bundle();
         mDelegate.onSaveInstanceState_afterSuper(bundle);
 
         mDelegate.onDestroy_afterSuper();
-        assertEquals(TiPresenter.State.CREATED_WITH_DETACHED_VIEW, mPresenter.getState());
+        assertEquals(TiPresenter.State.VIEW_DETACHED, mPresenter.getState());
 
         mPresenter = secondPresenter;
         mDelegate = newDelegate();
@@ -157,13 +157,13 @@ public class TiActivityDelegateTest {
 
         mDelegate.onCreate_afterSuper(null);
 
-        assertEquals(TiPresenter.State.CREATED_WITH_DETACHED_VIEW, mPresenter.getState());
+        assertEquals(TiPresenter.State.VIEW_DETACHED, mPresenter.getState());
 
         final Bundle bundle = new Bundle();
         mDelegate.onSaveInstanceState_afterSuper(bundle);
 
         mDelegate.onDestroy_afterSuper();
-        assertEquals(TiPresenter.State.CREATED_WITH_DETACHED_VIEW, mPresenter.getState());
+        assertEquals(TiPresenter.State.VIEW_DETACHED, mPresenter.getState());
 
         mPresenter = secondPresenter;
 
@@ -189,13 +189,13 @@ public class TiActivityDelegateTest {
 
         mDelegate.onCreate_afterSuper(null);
 
-        assertEquals(TiPresenter.State.CREATED_WITH_DETACHED_VIEW, mPresenter.getState());
+        assertEquals(TiPresenter.State.VIEW_DETACHED, mPresenter.getState());
 
         final Bundle bundle = new Bundle();
         mDelegate.onSaveInstanceState_afterSuper(bundle);
 
         mDelegate.onDestroy_afterSuper();
-        assertEquals(TiPresenter.State.CREATED_WITH_DETACHED_VIEW, mPresenter.getState());
+        assertEquals(TiPresenter.State.VIEW_DETACHED, mPresenter.getState());
 
         mPresenter = secondPresenter;
 
@@ -204,7 +204,7 @@ public class TiActivityDelegateTest {
         assertEquals(secondPresenter, mDelegate.getPresenter());
 
         // new one got created
-        assertEquals(TiPresenter.State.CREATED_WITH_DETACHED_VIEW, mPresenter.getState());
+        assertEquals(TiPresenter.State.VIEW_DETACHED, mPresenter.getState());
     }
 
     @NonNull

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
@@ -191,7 +191,6 @@ public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
 
     @Override
     protected void onStart() {
-        mDelegate.onStart_beforeSuper();
         super.onStart();
         mDelegate.onStart_afterSuper();
     }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiFragment.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiFragment.java
@@ -193,7 +193,7 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView>
 
     @Override
     public void onDestroyView() {
-        mPresenter.sleep();
+        mPresenter.detachView();
         super.onDestroyView();
     }
 
@@ -209,12 +209,11 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView>
         mActivityStarted = true;
 
         if (isUiPossible()) {
-            mViewBinder.bindView(mPresenter, this);
             getActivity().getWindow().getDecorView().post(new Runnable() {
                 @Override
                 public void run() {
                     if (isUiPossible() && mActivityStarted) {
-                        mPresenter.wakeUp();
+                        mViewBinder.bindView(mPresenter, TiFragment.this);
                     }
                 }
             });
@@ -224,7 +223,7 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView>
     @Override
     public void onStop() {
         mActivityStarted = false;
-        mPresenter.sleep();
+        mPresenter.detachView();
         super.onStop();
     }
 

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
@@ -323,16 +323,15 @@ public abstract class TiPresenter<V extends TiView> {
     }
 
     /**
-     * The view is now attached and ready to receive events. {@link #getView()} is not guaranteed
-     * to
-     * be not <code>null</code>
+     * The view is now attached and ready to receive events.
      *
-     * @see #onSleep()
+     * @see #onDetachView()
+     * @see #attachView(TiView)
      */
     protected void onAttachView(@NonNull V view) {
         if (mCalled) {
             throw new IllegalAccessError(
-                    "don't call #onAttachView() directly, call #attachView(TiView)");
+                    "don't call #onAttachView(TiView) directly, call #attachView(TiView)");
         }
         mCalled = true;
     }
@@ -370,11 +369,12 @@ public abstract class TiPresenter<V extends TiView> {
      * Right after this method the view will be detached. {@link #getView()} will return
      * <code>null</code> afterwards.
      *
+     * @see #onAttachView(TiView)
      * @see #detachView()
      */
     protected void onDetachView() {
         if (mCalled) {
-            throw new IllegalAccessError("don't call #onSleep() directly, call #detachView()");
+            throw new IllegalAccessError("don't call #onDetachView() directly, call #detachView()");
         }
         mCalled = true;
     }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/PresenterViewBinder.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/PresenterViewBinder.java
@@ -80,10 +80,10 @@ public class PresenterViewBinder<V extends TiView> implements InterceptableViewB
             }
             mLastView = interceptedView;
             TiLog.v(mLogTag.getLoggingTag(), "binding NEW view to Presenter " + mLastView);
-            presenter.bindNewView(mLastView);
+            presenter.attachView(mLastView);
         } else {
             TiLog.v(mLogTag.getLoggingTag(), "binding the cached view to Presenter " + mLastView);
-            presenter.bindNewView(mLastView);
+            presenter.attachView(mLastView);
         }
     }
 

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegate.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegate.java
@@ -245,18 +245,14 @@ public class TiActivityDelegate<P extends TiPresenter<V>, V extends TiView>
                 // check if still started. It happens that onStop got already called, specially
                 // when the Activity is not the top Activity and a configuration change happens
                 if (mActivityStarted) {
-                    mPresenter.wakeUp();
+                    mViewBinder.bindView(mPresenter, mViewProvider);
                 }
             }
         });
     }
 
-    public void onStart_beforeSuper() {
-        mViewBinder.bindView(mPresenter, mViewProvider);
-    }
-
     public void onStop_afterSuper() {
-        mPresenter.sleep();
+        mPresenter.detachView();
     }
 
     public void onStop_beforeSuper() {

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/TiLifecycleObserverTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/TiLifecycleObserverTest.java
@@ -62,9 +62,8 @@ public class TiLifecycleObserverTest {
         });
 
         mPresenter.create();
-        mPresenter.bindNewView(mView);
-        mPresenter.wakeUp();
-        mPresenter.sleep();
+        mPresenter.attachView(mView);
+        mPresenter.detachView();
         mPresenter.destroy();
 
         final Object[] beforeLast = states.get(states.size() - 2);
@@ -90,11 +89,11 @@ public class TiLifecycleObserverTest {
         mPresenter.create();
 
         final Object[] beforeLast = states.get(states.size() - 2);
-        assertEquals(beforeLast[0], TiPresenter.State.CREATED_WITH_DETACHED_VIEW);
+        assertEquals(beforeLast[0], TiPresenter.State.VIEW_DETACHED);
         assertEquals(beforeLast[1], false);
 
         final Object[] last = states.get(states.size() - 1);
-        assertEquals(last[0], TiPresenter.State.CREATED_WITH_DETACHED_VIEW);
+        assertEquals(last[0], TiPresenter.State.VIEW_DETACHED);
         assertEquals(last[1], true);
     }
 
@@ -112,23 +111,22 @@ public class TiLifecycleObserverTest {
         mPresenter.create();
 
         final Object[] beforeLast = states.get(states.size() - 2);
-        assertEquals(beforeLast[0], TiPresenter.State.CREATED_WITH_DETACHED_VIEW);
+        assertEquals(beforeLast[0], TiPresenter.State.VIEW_DETACHED);
         assertEquals(beforeLast[1], false);
 
         final Object[] last = states.get(states.size() - 1);
-        assertEquals(last[0], TiPresenter.State.CREATED_WITH_DETACHED_VIEW);
+        assertEquals(last[0], TiPresenter.State.VIEW_DETACHED);
         assertEquals(last[1], true);
 
         removable.remove();
 
-        mPresenter.bindNewView(mView);
-        mPresenter.wakeUp();
+        mPresenter.attachView(mView);
 
         final Object[] beforeLast2 = states.get(states.size() - 2);
-        assertNotEquals(beforeLast2[0], TiPresenter.State.VIEW_ATTACHED_AND_AWAKE);
+        assertNotEquals(beforeLast2[0], TiPresenter.State.VIEW_ATTACHED);
 
         final Object[] last2 = states.get(states.size() - 1);
-        assertNotEquals(last2[0], TiPresenter.State.VIEW_ATTACHED_AND_AWAKE);
+        assertNotEquals(last2[0], TiPresenter.State.VIEW_ATTACHED);
     }
 
     @Test
@@ -168,16 +166,15 @@ public class TiLifecycleObserverTest {
         });
 
         mPresenter.create();
-        mPresenter.bindNewView(mView);
-        mPresenter.wakeUp();
-        mPresenter.sleep();
+        mPresenter.attachView(mView);
+        mPresenter.detachView();
 
         final Object[] beforeLast = states.get(states.size() - 2);
-        assertEquals(beforeLast[0], TiPresenter.State.CREATED_WITH_DETACHED_VIEW);
+        assertEquals(beforeLast[0], TiPresenter.State.VIEW_DETACHED);
         assertEquals(beforeLast[1], false);
 
         final Object[] last = states.get(states.size() - 1);
-        assertEquals(last[0], TiPresenter.State.CREATED_WITH_DETACHED_VIEW);
+        assertEquals(last[0], TiPresenter.State.VIEW_DETACHED);
         assertEquals(last[1], true);
     }
 
@@ -193,15 +190,14 @@ public class TiLifecycleObserverTest {
         });
 
         mPresenter.create();
-        mPresenter.bindNewView(mView);
-        mPresenter.wakeUp();
+        mPresenter.attachView(mView);
 
         final Object[] beforeLast = states.get(states.size() - 2);
-        assertEquals(beforeLast[0], TiPresenter.State.VIEW_ATTACHED_AND_AWAKE);
+        assertEquals(beforeLast[0], TiPresenter.State.VIEW_ATTACHED);
         assertEquals(beforeLast[1], false);
 
         final Object[] last = states.get(states.size() - 1);
-        assertEquals(last[0], TiPresenter.State.VIEW_ATTACHED_AND_AWAKE);
+        assertEquals(last[0], TiPresenter.State.VIEW_ATTACHED);
         assertEquals(last[1], true);
     }
 }

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/TiPresenterTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/TiPresenterTest.java
@@ -93,10 +93,6 @@ public class TiPresenterTest {
 
     @Test
     public void attachWithoutInitialize() throws Exception {
-
-        // not calling
-        // mPresenter.create();
-
         try {
             mPresenter.attachView(mView);
             fail("no exception thrown");
@@ -156,6 +152,7 @@ public class TiPresenterTest {
             fail("no exception thrown");
         } catch (IllegalAccessError e) {
             assertTrue(e.getMessage().contains("attachView(TiView)"));
+            assertTrue(e.getMessage().contains("#onAttachView(TiView)"));
         }
     }
 
@@ -166,6 +163,7 @@ public class TiPresenterTest {
             fail("no exception thrown");
         } catch (IllegalAccessError e) {
             assertTrue(e.getMessage().contains("create()"));
+            assertTrue(e.getMessage().contains("#onCreate()"));
         }
     }
 
@@ -176,6 +174,7 @@ public class TiPresenterTest {
             fail("no exception thrown");
         } catch (IllegalAccessError e) {
             assertTrue(e.getMessage().contains("destroy()"));
+            assertTrue(e.getMessage().contains("#onDestroy()"));
         }
     }
 
@@ -186,6 +185,7 @@ public class TiPresenterTest {
             fail("no exception thrown");
         } catch (IllegalAccessError e) {
             assertTrue(e.getMessage().contains("detachView()"));
+            assertTrue(e.getMessage().contains("#onDetachView()"));
         }
     }
 
@@ -196,6 +196,7 @@ public class TiPresenterTest {
             fail("no exception thrown");
         } catch (IllegalAccessError e) {
             assertTrue(e.getMessage().contains("detachView()"));
+            assertTrue(e.getMessage().contains("#onSleep()"));
         }
     }
 
@@ -206,6 +207,7 @@ public class TiPresenterTest {
             fail("no exception thrown");
         } catch (IllegalAccessError e) {
             assertTrue(e.getMessage().contains("attachView(TiView)"));
+            assertTrue(e.getMessage().contains("#onWakeUp()"));
         }
     }
 

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/TiPresenterTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/TiPresenterTest.java
@@ -19,12 +19,14 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import android.support.annotation.NonNull;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.fail;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -36,6 +38,104 @@ public class TiPresenterTest {
     private TiMockPresenter mPresenter;
 
     private TiView mView;
+
+    @Test
+    public void attachDifferentView() throws Exception {
+        TiView viewOverride = mock(TiView.class);
+        mPresenter.create();
+
+        mPresenter.attachView(mView);
+        assertThat(mPresenter.getView(), equalTo(mView));
+
+        try {
+            mPresenter.attachView(viewOverride);
+            fail("no exception thrown");
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage().contains("detachView"));
+        }
+    }
+
+    @Test
+    public void attachNullView() throws Exception {
+
+        mPresenter.create();
+        try {
+            mPresenter.attachView(null);
+            fail("no exception thrown");
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage().contains("detachView()"));
+        }
+    }
+
+    @Test
+    public void attachSameViewTwice() throws Exception {
+        mPresenter.create();
+
+        mPresenter.attachView(mView);
+        assertThat(mPresenter.getView(), equalTo(mView));
+
+        mPresenter.attachView(mView);
+        assertThat(mPresenter.getView(), equalTo(mView));
+    }
+
+    @Test
+    public void attachViewToDestroyedPresenter() throws Exception {
+        mPresenter.create();
+        mPresenter.destroy();
+
+        try {
+            mPresenter.attachView(mView);
+            fail("no exception thrown");
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage().contains("terminal state"));
+        }
+    }
+
+    @Test
+    public void attachWithoutInitialize() throws Exception {
+
+        // not calling
+        // mPresenter.create();
+
+        try {
+            mPresenter.attachView(mView);
+            fail("no exception thrown");
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage().contains("create()"));
+        }
+    }
+
+    @Test
+    public void destroyWithoutAttachingView() throws Exception {
+        mPresenter.create();
+        mPresenter.destroy();
+    }
+
+    @Test
+    public void detachView() throws Exception {
+        mPresenter.create();
+        assertEquals(null, mPresenter.getView());
+
+        final TiView view = mock(TiView.class);
+        mPresenter.attachView(view);
+        assertEquals(view, mPresenter.getView());
+
+        mPresenter.detachView();
+        assertEquals(null, mPresenter.getView());
+    }
+
+    @Test
+    public void detachViewNotAttached() throws Exception {
+        mPresenter.create();
+
+        // no exception, just ignoring
+        mPresenter.detachView();
+
+        mPresenter.attachView(mock(TiView.class));
+        // no exception, just ignoring
+        mPresenter.detachView();
+        mPresenter.detachView();
+    }
 
     @Before
     public void setUp() throws Exception {
@@ -50,30 +150,63 @@ public class TiPresenterTest {
     }
 
     @Test
-    public void testBindNewView() throws Exception {
-        TiView viewOverride = mock(TiView.class);
-        mPresenter.create();
-        mPresenter.bindNewView(mView);
-
-        assertThat(mPresenter.getView(), equalTo(mView));
-
-        mPresenter.bindNewView(mView);
-        assertThat(mPresenter.getView(), equalTo(mView));
-
-        mPresenter.bindNewView(viewOverride);
-        assertThat(mPresenter.getView(), equalTo(viewOverride));
-
+    public void testCallingOnAttachViewDirectly() throws Exception {
         try {
-            mPresenter.bindNewView(null);
-            fail();
-        } catch (IllegalStateException e) {
-            assertTrue(e.getMessage().contains("sleep"));
+            mPresenter.onAttachView(mock(TiView.class));
+            fail("no exception thrown");
+        } catch (IllegalAccessError e) {
+            assertTrue(e.getMessage().contains("attachView(TiView)"));
         }
+    }
 
-        mPresenter.wakeUp();
-        assertThat(mPresenter.getView(), equalTo(viewOverride));
-        mPresenter.sleep();
-        assertThat(mPresenter.getView(), nullValue());
+    @Test
+    public void testCallingOnCreateDirectly() throws Exception {
+        try {
+            mPresenter.onCreate();
+            fail("no exception thrown");
+        } catch (IllegalAccessError e) {
+            assertTrue(e.getMessage().contains("create()"));
+        }
+    }
+
+    @Test
+    public void testCallingOnDestroyDirectly() throws Exception {
+        try {
+            mPresenter.onDestroy();
+            fail("no exception thrown");
+        } catch (IllegalAccessError e) {
+            assertTrue(e.getMessage().contains("destroy()"));
+        }
+    }
+
+    @Test
+    public void testCallingOnDetachViewDirectly() throws Exception {
+        try {
+            mPresenter.onDetachView();
+            fail("no exception thrown");
+        } catch (IllegalAccessError e) {
+            assertTrue(e.getMessage().contains("detachView()"));
+        }
+    }
+
+    @Test
+    public void testCallingOnSleepDirectly() throws Exception {
+        try {
+            mPresenter.onSleep();
+            fail("no exception thrown");
+        } catch (IllegalAccessError e) {
+            assertTrue(e.getMessage().contains("detachView()"));
+        }
+    }
+
+    @Test
+    public void testCallingOnWakeUpDirectly() throws Exception {
+        try {
+            mPresenter.onWakeUp();
+            fail("no exception thrown");
+        } catch (IllegalAccessError e) {
+            assertTrue(e.getMessage().contains("attachView(TiView)"));
+        }
     }
 
     @Test
@@ -97,7 +230,6 @@ public class TiPresenterTest {
         };
         presenter.create();
     }
-
 
     @Test
     public void testDestroy() throws Exception {
@@ -133,33 +265,48 @@ public class TiPresenterTest {
     @Test
     public void testGetView() throws Exception {
         mPresenter.create();
-        mPresenter.bindNewView(mView);
+        mPresenter.attachView(mView);
         assertThat(mPresenter.getView(), equalTo(mView));
     }
 
+    @Test
+    public void testOnAttachViewSuperNotCalled() throws Exception {
+        TiPresenter<TiView> presenter = new TiPresenter<TiView>() {
 
-    @Test(expected = IllegalAccessError.class)
-    public void testOnCreate() throws Exception {
-        mPresenter.onCreate();
+            @Override
+            protected void onAttachView(@NonNull final TiView view) {
+                // Intentionally not calling super.onSleep()
+            }
+        };
+        presenter.create();
+        try {
+            presenter.attachView(mock(TiView.class));
+            fail("no exception thrown");
+        } catch (SuperNotCalledException e) {
+            assertTrue(e.getMessage().contains("super.onAttachView(TiView)"));
+        }
     }
 
-    @Test(expected = IllegalAccessError.class)
-    public void testOnDestroy() throws Exception {
-        mPresenter.onDestroy();
+    @Test
+    public void testOnDetachViewSuperNotCalled() throws Exception {
+        TiPresenter<TiView> presenter = new TiPresenter<TiView>() {
+
+            @Override
+            protected void onDetachView() {
+                // Intentionally not calling super.onSleep()
+            }
+        };
+        presenter.create();
+        presenter.attachView(mock(TiView.class));
+        try {
+            presenter.detachView();
+            fail("no exception thrown");
+        } catch (SuperNotCalledException e) {
+            assertTrue(e.getMessage().contains("super.onDetachView()"));
+        }
     }
 
-    @Test(expected = IllegalAccessError.class)
-    public void testOnSleep() throws Exception {
-        mPresenter.onSleep();
-    }
-
-    @Test(expected = IllegalAccessError.class)
-    public void testOnWakeUp() throws Exception {
-        mPresenter.onWakeUp();
-    }
-
-
-    @Test(expected = SuperNotCalledException.class)
+    @Test
     public void testSleepSuperNotCalled() throws Exception {
         TiPresenter<TiView> presenter = new TiPresenter<TiView>() {
             @Override
@@ -168,8 +315,13 @@ public class TiPresenterTest {
             }
         };
         presenter.create();
-        presenter.wakeUp();
-        presenter.sleep();
+        presenter.attachView(mock(TiView.class));
+        try {
+            presenter.detachView();
+            fail("no exception thrown");
+        } catch (SuperNotCalledException e) {
+            assertTrue(e.getMessage().contains("super.onSleep()"));
+        }
     }
 
     @Test
@@ -177,23 +329,13 @@ public class TiPresenterTest {
         mPresenter.create();
         assertThat(mPresenter.toString(), containsString("TiMockPresenter"));
         assertThat(mPresenter.toString(), containsString("{view = null}"));
-        mPresenter.bindNewView(mView);
+        mPresenter.attachView(mView);
         assertThat(mPresenter.toString(), containsString("TiMockPresenter"));
         assertThat(mPresenter.toString(), containsString("{view = Mock for TiView, hashCode: "));
     }
 
-    @Test
-    public void testWakeUp() throws Exception {
-        mPresenter.create();
-        assertThat(mPresenter.onWakeUpCalled, equalTo(0));
-        mPresenter.wakeUp();
-        assertThat(mPresenter.onWakeUpCalled, equalTo(1));
-        // not calling again
-        mPresenter.wakeUp();
-        assertThat(mPresenter.onWakeUpCalled, equalTo(1));
-    }
 
-    @Test(expected = SuperNotCalledException.class)
+    @Test
     public void testWakeUpSuperNotCalled() throws Exception {
         TiPresenter<TiView> presenter = new TiPresenter<TiView>() {
             @Override
@@ -202,6 +344,11 @@ public class TiPresenterTest {
             }
         };
         presenter.create();
-        presenter.wakeUp();
+        try {
+            presenter.attachView(mock(TiView.class));
+            fail("no exception thrown");
+        } catch (SuperNotCalledException e) {
+            assertTrue(e.getMessage().contains("super.onWakeUp()"));
+        }
     }
 }


### PR DESCRIPTION
The new naming is more convenient throughout most android MPV libraries. Switching to `Ti` should now be simpler. It reflects better that it's only about the view being absent. wakeup and sleep could imply the Presenter is kind of starting/stopping which is not the case.

`onAttachView(TiView)` has the attached view as first parameter which is `@NonNull`. No calls to `getView()` are neccessary inside `onAttachView(TiView)`.
`getView()` is now `@Nullable` (and always was null when not between `wakeup()` and `sleep()` state) and causes lint to hint a Nullable warning. This warning was missing and caused a lot of NPE for `Ti` beginners