### PR TITLE
Fix view beeing null before unsubscribing from Subscriptions

### DIFF
--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
@@ -265,8 +265,8 @@ public abstract class TiPresenter<V extends TiView> {
                     + " did not call through to super.onDetachView()");
         }
 
-        mView = null;
         moveToState(State.VIEW_DETACHED, true);
+        mView = null;
     }
 
     /**

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/TiLifecycleObserverTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/TiLifecycleObserverTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+import static junit.framework.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Mockito.mock;
@@ -161,7 +162,7 @@ public class TiLifecycleObserverTest {
             @Override
             public void onChange(final TiPresenter.State state,
                     final boolean beforeLifecycleEvent) {
-                states.add(new Object[]{state, beforeLifecycleEvent});
+                states.add(new Object[]{state, beforeLifecycleEvent, mPresenter.getView()});
             }
         });
 
@@ -172,10 +173,12 @@ public class TiLifecycleObserverTest {
         final Object[] beforeLast = states.get(states.size() - 2);
         assertEquals(beforeLast[0], TiPresenter.State.VIEW_DETACHED);
         assertEquals(beforeLast[1], false);
+        assertNotNull(beforeLast[2]);
 
         final Object[] last = states.get(states.size() - 1);
         assertEquals(last[0], TiPresenter.State.VIEW_DETACHED);
         assertEquals(last[1], true);
+        assertNotNull(last[2]);
     }
 
     @Test
@@ -185,7 +188,7 @@ public class TiLifecycleObserverTest {
             @Override
             public void onChange(final TiPresenter.State state,
                     final boolean beforeLifecycleEvent) {
-                states.add(new Object[]{state, beforeLifecycleEvent});
+                states.add(new Object[]{state, beforeLifecycleEvent, mPresenter.getView()});
             }
         });
 
@@ -195,9 +198,11 @@ public class TiLifecycleObserverTest {
         final Object[] beforeLast = states.get(states.size() - 2);
         assertEquals(beforeLast[0], TiPresenter.State.VIEW_ATTACHED);
         assertEquals(beforeLast[1], false);
+        assertNotNull(beforeLast[2]);
 
         final Object[] last = states.get(states.size() - 1);
         assertEquals(last[0], TiPresenter.State.VIEW_ATTACHED);
         assertEquals(last[1], true);
+        assertNotNull(last[2]);
     }
 }


### PR DESCRIPTION
When using the `RxTiPresenterSubscriptionHandler` to automatically unsubscribe from views it can happen that `getView()` is already `null` before `Subscriptions#unsubscribe()` is called. This is caused by the `VIEW_DETACHED` lifecycle event after super is called after `mView` is set to `null`. Changing the order fixes the Problem.

From sample `HelloWorldPresenter.java`

``` java
    @Override
    protected void onAttachView(@NonNull final HelloWorldView view) {
        super.onAttachView(view);

        rxSubscriptionHelper.manageViewSubscription(mText.asObservable()
                .subscribe(new Action1<String>() {
                    @Override
                    public void call(final String text) {
                        // getView() can be null before this Observer is unsubscribed
                        getView().showText(text);
                    }
                }));
    }

```
