### PR TITLE
Revert using equals instead of hashcode

### DIFF
--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChanged.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChanged.java
@@ -27,14 +27,14 @@ import java.lang.annotation.Target;
  * When added to a {@code void} method with at least one parameter inside a {@link TiView}, the
  * method implementation will only be called when the parameters change. A
  * {@link DistinctComparator} class is used to detect changes. By default it uses
- * {@link EqualsComparator}.
+ * {@link HashComparator}.
  */
 @Documented
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DistinctUntilChanged {
 
-    Class<? extends DistinctComparator> comparator() default EqualsComparator.class;
+    Class<? extends DistinctComparator> comparator() default HashComparator.class;
 
     boolean logDropped() default false;
 

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/EqualsComparator.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/EqualsComparator.java
@@ -20,15 +20,16 @@ import java.util.Arrays;
 /**
  * A {@link DistinctComparator} implementation which uses the {@link Object#equals(Object)}
  * method of the parameters to detect changes. It holds a strong reference to the previously used
- * parameters for a real {@link Object#equals(Object)} comparison.
+ * parameters for a real {@link Object#equals(Object)} comparison known from RxJavas {@code
+ * Observable#distinctUntilChanged()} operator.
  * <p>
- * This comparison may lead to errors when the annotated method is called with mutable objects.
- * Both, this Comparator and the Presenter hold a reference to the same object. When the Presenter
- * mutates the object and sends it to the View the comparison detects equal objects although the
- * object differs from the last received object in the View. This results in not calling the
- * annotated method.
+ * <b>Caution:</b> This comparison may lead to errors when the annotated method is called with
+ * mutable objects. Both, this Comparator and the Presenter hold a reference to the same object.
+ * When the Presenter mutates the object and sends it to the View the comparison detects equal
+ * objects although the object differs from the last received object in the View. This results in
+ * not calling the annotated method. See {@code DistinctUntilChangedEqualsProblem} for an example
  * <p>
- * The strong reference to the previous parameters could cause problems when dealing with big
+ * The strong reference to the previous parameters could also cause problems when dealing with big
  * data blobs such as bitmaps. Consider using a simpler comparator like {@link HashComparator} or
  * {@link WeakEqualsComparator}.
  */

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/EqualsComparator.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/EqualsComparator.java
@@ -19,8 +19,14 @@ import java.util.Arrays;
 
 /**
  * A {@link DistinctComparator} implementation which uses the {@link Object#equals(Object)}
- * method of the parameters to detect changes. It holds a strong reference to the previously use
+ * method of the parameters to detect changes. It holds a strong reference to the previously used
  * parameters for a real {@link Object#equals(Object)} comparison.
+ * <p>
+ * This comparison may lead to errors when the annotated method is called with mutable objects.
+ * Both, this Comparator and the Presenter hold a reference to the same object. When the Presenter
+ * mutates the object and sends it to the View the comparison detects equal objects although the
+ * object differs from the last received object in the View. This results in not calling the
+ * annotated method.
  * <p>
  * The strong reference to the previous parameters could cause problems when dealing with big
  * data blobs such as bitmaps. Consider using a simpler comparator like {@link HashComparator} or

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedEqualsProblem.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedEqualsProblem.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2016 grandcentrix GmbH
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.grandcentrix.thirtyinch.distinctuntilchanged;
+
+
+import net.grandcentrix.thirtyinch.TiView;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class DistinctUntilChangedEqualsProblem {
+
+    /**
+     * Mutable pojo
+     */
+    private static class Tab {
+
+        private String name;
+
+        public Tab(final String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Tab)) {
+                return false;
+            }
+
+            final Tab tab = (Tab) o;
+
+            return name != null ? name.equals(tab.name) : tab.name == null;
+
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public int hashCode() {
+            return name != null ? name.hashCode() : 0;
+        }
+
+        public void setName(final String name) {
+            this.name = name;
+        }
+    }
+
+    // Impl because Mockito mocks cannot be wrapped in a proxy
+    private static class TestViewImpl implements TestView {
+
+        int equalsCalled = 0;
+
+        int hashCalled = 0;
+
+        @Override
+        public void showTabsEquals(final List<Tab> tabs) {
+            equalsCalled++;
+        }
+
+        @Override
+        public void showTabsHash(final List<Tab> tabs) {
+            hashCalled++;
+        }
+    }
+
+    private interface TestView extends TiView {
+
+        @DistinctUntilChanged(comparator = EqualsComparator.class)
+        void showTabsEquals(final List<Tab> tabs);
+
+        @DistinctUntilChanged(comparator = HashComparator.class)
+        void showTabsHash(final List<Tab> tabs);
+    }
+
+    private Tab tab1 = new Tab("A");
+
+    private Tab tab2 = new Tab("B");
+
+    private Tab tab3 = new Tab("C");
+
+    private TestViewImpl view;
+
+    private TestView wrappedView;
+
+    @Test
+    public void mutatedObjectIsDetectedByHashCodeComparator() throws Exception {
+
+        // call view for the first time
+        final List<Tab> list1 = Arrays.asList(tab1, tab2, tab3);
+        wrappedView.showTabsHash(list1);
+        assertThat(view.hashCalled).isEqualTo(1);
+
+        // mutate one tab
+        tab1.setName("X");
+
+        // create list with same tab objects
+        final List<Tab> list2 = Arrays.asList(tab1, tab2, tab3);
+        wrappedView.showTabsHash(list2);
+
+        // view gets called on change
+        assertThat(view.hashCalled).isEqualTo(2);
+    }
+
+    @Test
+    public void mutatedObjectIsNotDetectedByEqualsComparator() throws Exception {
+
+        // call view for the first time
+        final List<Tab> list1 = Arrays.asList(tab1, tab2, tab3);
+        wrappedView.showTabsEquals(list1);
+        assertThat(view.equalsCalled).isEqualTo(1);
+
+        // mutate one tab
+        tab1.setName("X");
+
+        // create list with same tab objects
+        final List<Tab> list2 = Arrays.asList(tab1, tab2, tab3);
+        wrappedView.showTabsEquals(list2);
+
+        // view doesn't get called because the objects are still the same (by reference)
+        // this is expected but it's very confusing because the content has changed since the
+        // last call. This happens when mutable objects are used as parameters
+        assertThat(view.equalsCalled).isEqualTo(1);
+    }
+
+    @Before
+    public void _setUp() {
+        view = new TestViewImpl();
+        final DistinctUntilChangedInterceptor interceptor = new DistinctUntilChangedInterceptor();
+        wrappedView = interceptor.intercept(view);
+        // check wrapping worked
+        assertThat(view).isNotEqualTo(wrappedView);
+    }
+}

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedEqualsProblem.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedEqualsProblem.java
@@ -105,8 +105,17 @@ public class DistinctUntilChangedEqualsProblem {
 
     private TestView wrappedView;
 
+    @Before
+    public void setUp() {
+        view = new TestViewImpl();
+        final DistinctUntilChangedInterceptor interceptor = new DistinctUntilChangedInterceptor();
+        wrappedView = interceptor.intercept(view);
+        // check wrapping worked
+        assertThat(view).isNotEqualTo(wrappedView);
+    }
+
     @Test
-    public void mutatedObjectIsDetectedByHashCodeComparator() throws Exception {
+    public void testMutatedObjectIsDetectedByHashCodeComparator() throws Exception {
 
         // call view for the first time
         final List<Tab> list1 = Arrays.asList(tab1, tab2, tab3);
@@ -125,7 +134,7 @@ public class DistinctUntilChangedEqualsProblem {
     }
 
     @Test
-    public void mutatedObjectIsNotDetectedByEqualsComparator() throws Exception {
+    public void testMutatedObjectIsNotDetectedByEqualsComparator() throws Exception {
 
         // call view for the first time
         final List<Tab> list1 = Arrays.asList(tab1, tab2, tab3);
@@ -143,14 +152,5 @@ public class DistinctUntilChangedEqualsProblem {
         // this is expected but it's very confusing because the content has changed since the
         // last call. This happens when mutable objects are used as parameters
         assertThat(view.equalsCalled).isEqualTo(1);
-    }
-
-    @Before
-    public void _setUp() {
-        view = new TestViewImpl();
-        final DistinctUntilChangedInterceptor interceptor = new DistinctUntilChangedInterceptor();
-        wrappedView = interceptor.intercept(view);
-        // check wrapping worked
-        assertThat(view).isNotEqualTo(wrappedView);
     }
 }

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandlerTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandlerTest.java
@@ -82,6 +82,12 @@ public class DistinctUntilChangedInvocationHandlerTest {
 
     private DistinctUntilChangedInvocationHandler<TestView> handler;
 
+    @Before
+    public void _setUp() {
+        ducView = new TestView();
+        handler = new DistinctUntilChangedInvocationHandler<>(ducView);
+    }
+
     @Test
     public void callNonTiViewMethods() throws Throwable {
 
@@ -139,12 +145,6 @@ public class DistinctUntilChangedInvocationHandlerTest {
         } catch (IllegalStateException e) {
             assertThat(e).hasMessage("Blubb123");
         }
-    }
-
-    @Before
-    public void setUp() {
-        ducView = new TestView();
-        handler = new DistinctUntilChangedInvocationHandler<>(ducView);
     }
 
     @Test

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandlerTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInvocationHandlerTest.java
@@ -7,9 +7,9 @@ import org.junit.Test;
 
 import java.lang.reflect.Method;
 
+import static junit.framework.Assert.assertEquals;
 import static org.assertj.core.api.Java6Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Java6Assertions.fail;
 
 public class DistinctUntilChangedInvocationHandlerTest {
 
@@ -83,13 +83,13 @@ public class DistinctUntilChangedInvocationHandlerTest {
     private DistinctUntilChangedInvocationHandler<TestView> handler;
 
     @Before
-    public void _setUp() {
+    public void setUp() {
         ducView = new TestView();
         handler = new DistinctUntilChangedInvocationHandler<>(ducView);
     }
 
     @Test
-    public void callNonTiViewMethods() throws Throwable {
+    public void testCallNonTiViewMethods() throws Throwable {
 
         assertThat(ducView.something).isEqualTo(0);
         final Method method = ducView.getClass().getMethod("doSomething", String.class);
@@ -100,7 +100,7 @@ public class DistinctUntilChangedInvocationHandlerTest {
     }
 
     @Test
-    public void directlyCallNonVoid() throws Throwable {
+    public void testDirectlyCallNonVoid() throws Throwable {
         final Method method = ducView.getClass().getMethod("returnValueOneArg", String.class);
         assertThat(handler.handleInvocation(null, method, new Object[]{"test"}))
                 .isEqualTo("success1");
@@ -109,7 +109,7 @@ public class DistinctUntilChangedInvocationHandlerTest {
     }
 
     @Test
-    public void directlyCallNotAnnotatedMethods() throws Throwable {
+    public void testDirectlyCallNotAnnotatedMethods() throws Throwable {
         assertThat(ducView.notAnnotated).isEqualTo(0);
         final Method method = ducView.getClass().getMethod("notAnnotated", String.class);
         handler.handleInvocation(null, method, new Object[]{"hi"});
@@ -119,14 +119,14 @@ public class DistinctUntilChangedInvocationHandlerTest {
     }
 
     @Test
-    public void directlyCallObjectMethods() throws Throwable {
+    public void testDirectlyCallObjectMethods() throws Throwable {
         final Method method = ducView.getClass().getMethod("toString");
         assertThat((String) handler.handleInvocation(null, method, new Object[]{}))
                 .contains(TestView.class.getSimpleName());
     }
 
     @Test
-    public void directlyForwardCallsWithZeroArguments() throws Throwable {
+    public void testDirectlyForwardCallsWithZeroArguments() throws Throwable {
         assertThat(ducView.zeroArgsCount).isEqualTo(0);
         final Method method = ducView.getClass().getMethod("zeroArgs");
         handler.handleInvocation(null, method, new Object[]{});
@@ -136,7 +136,7 @@ public class DistinctUntilChangedInvocationHandlerTest {
     }
 
     @Test
-    public void methodsForwardExceptions() throws Throwable {
+    public void testMethodsForwardExceptions() throws Throwable {
         final Method method = ducView.getClass().getMethod("throwing", String.class);
 
         try {
@@ -148,7 +148,7 @@ public class DistinctUntilChangedInvocationHandlerTest {
     }
 
     @Test
-    public void shouldCallMethodAfterClearCache() throws Throwable {
+    public void testShouldCallMethodAfterClearCache() throws Throwable {
         //given
         final Method method = ducView.getClass().getMethod("ducMethod", String.class);
         Object[] args = new Object[]{"p1"};
@@ -169,7 +169,7 @@ public class DistinctUntilChangedInvocationHandlerTest {
     }
 
     @Test
-    public void shouldCallMethodOnce() throws Throwable {
+    public void testShouldCallMethodOnce() throws Throwable {
         //given
         final Method method = ducView.getClass().getMethod("ducMethod", String.class);
 
@@ -182,7 +182,7 @@ public class DistinctUntilChangedInvocationHandlerTest {
     }
 
     @Test
-    public void shouldCallMethodTwice() throws Throwable {
+    public void testShouldCallMethodTwice() throws Throwable {
         //given
         final Method method = ducView.getClass().getMethod("ducMethod", String.class);
 
@@ -196,7 +196,7 @@ public class DistinctUntilChangedInvocationHandlerTest {
     }
 
     @Test
-    public void swallowCall() throws Throwable {
+    public void testSwallowCall() throws Throwable {
         final Method method = ducView.getClass().getMethod("logDropped", String.class);
 
         assertEquals(0, ducView.callCount);
@@ -208,7 +208,7 @@ public class DistinctUntilChangedInvocationHandlerTest {
     }
 
     @Test
-    public void throwWhenInitializingABadComparator() throws Throwable {
+    public void testThrowWhenInitializingABadComparator() throws Throwable {
         final Method method = ducView.getClass().getMethod("badComparator", String.class);
 
         try {


### PR DESCRIPTION
We found problems in two of our apps when we migrated from `0.7.1` to `0.8.0-rc1`. View methods haven't been called because mutable objects have been used as parameters. After mutating those objects and calling the method again the View method wasn't called as expected. The parameter changed but the `EqualsComparator` is holding a reference to exactly this changed object. The second call simply detects the same object reference and omits forwarding the method call to the view.

After thinking a lot about this I think the hashcode solution is better. It stores the hashcode of the called object at the time it is called. At the next call it compares the current hashcode to the stored hashcode. This also works when the same object was mutated and changes will be detected.

Reverts #19, #24 