### PR TITLE
Suppress unchecked casts warnings

### DIFF
--- a/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiActivityPlugin.java
+++ b/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiActivityPlugin.java
@@ -101,12 +101,12 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
         return mDelegate.getPresenter();
     }
 
+    @SuppressWarnings("unchecked")
     @Nullable
     @Override
     public P getRetainedPresenter() {
         final Object nci = getLastNonConfigurationInstance(NCI_KEY_PRESENTER);
         if (nci != null) {
-            //noinspection unchecked
             return (P) nci;
         }
         return null;
@@ -193,6 +193,7 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
         return getActivity().getWindow().getDecorView().post(runnable);
     }
 
+    @SuppressWarnings("unchecked")
     @NonNull
     @Override
     public V provideView() {
@@ -210,7 +211,6 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
                                 + " This is the default behaviour. Override provideView() to explicitly change this.");
             } else {
                 // assume that the activity itself is the view and implements the TiView interface
-                //noinspection unchecked
                 return (V) getActivity();
             }
         }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
@@ -76,6 +76,7 @@ public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
         return mDelegate.getPresenter();
     }
 
+    @SuppressWarnings("unchecked")
     @Nullable
     @Override
     public P getRetainedPresenter() {
@@ -84,7 +85,6 @@ public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
         final Object nci = getLastCustomNonConfigurationInstance();
         if (nci instanceof PresenterNonConfigurationInstance) {
             final PresenterNonConfigurationInstance pnci = (PresenterNonConfigurationInstance) nci;
-            //noinspection unchecked
             return (P) pnci.getPresenter();
         }
         return null;
@@ -141,6 +141,7 @@ public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
         return getWindow().getDecorView().post(runnable);
     }
 
+    @SuppressWarnings("unchecked")
     @NonNull
     @Override
     public V provideView() {
@@ -158,7 +159,6 @@ public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
                                 + " This is the default behaviour. Override provideView() to explicitly change this.");
             } else {
                 // assume that the activity itself is the view and implements the TiView interface
-                //noinspection unchecked
                 return (V) this;
             }
         }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiDialogFragment.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiDialogFragment.java
@@ -148,6 +148,7 @@ public abstract class TiDialogFragment<P extends TiPresenter<V>, V extends TiVie
      *
      * @return the object implementing the TiView interface
      */
+    @SuppressWarnings("unchecked")
     @NonNull
     public V provideView() {
 
@@ -165,7 +166,6 @@ public abstract class TiDialogFragment<P extends TiPresenter<V>, V extends TiVie
                                 + " This is the default behaviour. Override provideView() to explicitly change this.");
             } else {
                 // assume that the fragment itself is the view and implements the TiView interface
-                //noinspection unchecked
                 return (V) this;
             }
         }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiFragment.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiFragment.java
@@ -162,6 +162,7 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView> ext
      *
      * @return the object implementing the TiView interface
      */
+    @SuppressWarnings("unchecked")
     @NonNull
     public V provideView() {
 
@@ -179,7 +180,6 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView> ext
                                 + " This is the default behaviour. Override provideView() to explicitly change this.");
             } else {
                 // assume that the fragment itself is the view and implements the TiView interface
-                //noinspection unchecked
                 return (V) this;
             }
         }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/callonmainthread/CallOnMainThreadInterceptor.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/callonmainthread/CallOnMainThreadInterceptor.java
@@ -35,6 +35,7 @@ public class CallOnMainThreadInterceptor implements BindViewInterceptor {
         return wrapped;
     }
 
+    @SuppressWarnings("unchecked")
     private <V extends TiView> V wrap(final V view) {
 
         Class<?> foundInterfaceClass = getInterfaceOfClassExtendingGivenInterface(
@@ -49,11 +50,8 @@ public class CallOnMainThreadInterceptor implements BindViewInterceptor {
             return view;
         }
 
-        //noinspection unchecked,UnnecessaryLocalVariable
-        final V wrappedView = (V) Proxy.newProxyInstance(
+        return (V) Proxy.newProxyInstance(
                 foundInterfaceClass.getClassLoader(), new Class<?>[]{foundInterfaceClass},
                 new CallOnMainThreadInvocationHandler<>(view));
-
-        return wrappedView;
     }
 }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctComparator.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctComparator.java
@@ -22,7 +22,7 @@ public interface DistinctComparator {
 
     /**
      * Checks if the arguments of a method call have changed compare to the last call of the
-     * method. This method returns {@link false} when calling it for the first time. It's the
+     * method. This method returns {@code false} when calling it for the first time. It's the
      * initialization step allowing comparisons with the next arguments.
      *
      * @param newParameters arguments of the current method call. Compare them to the last call

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInterceptor.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/distinctuntilchanged/DistinctUntilChangedInterceptor.java
@@ -32,10 +32,10 @@ public class DistinctUntilChangedInterceptor implements BindViewInterceptor {
 
     private static final String TAG = DistinctUntilChangedInterceptor.class.getSimpleName();
 
+    @SuppressWarnings("unchecked")
     @Nullable
     public static DistinctUntilChangedInvocationHandler<TiView> unwrap(@NonNull final TiView view) {
         try {
-            //noinspection unchecked
             return (DistinctUntilChangedInvocationHandler) Proxy.getInvocationHandler(view);
         } catch (ClassCastException e) {
             return null;
@@ -61,6 +61,7 @@ public class DistinctUntilChangedInterceptor implements BindViewInterceptor {
         return wrapped;
     }
 
+    @SuppressWarnings("unchecked")
     @NonNull
     public <V extends TiView> V wrap(@NonNull final V view) {
 
@@ -76,11 +77,8 @@ public class DistinctUntilChangedInterceptor implements BindViewInterceptor {
             return view;
         }
 
-        //noinspection unchecked,UnnecessaryLocalVariable
-        final V wrappedView = (V) Proxy.newProxyInstance(
+        return (V) Proxy.newProxyInstance(
                 foundInterfaceClass.getClassLoader(), new Class<?>[]{foundInterfaceClass},
                 new DistinctUntilChangedInvocationHandler<>(view));
-
-        return wrappedView;
     }
 }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegate.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegate.java
@@ -123,6 +123,7 @@ public class TiActivityDelegate<P extends TiPresenter<V>, V extends TiView>
         mViewBinder.invalidateView();
     }
 
+    @SuppressWarnings("unchecked")
     public void onCreate_afterSuper(final Bundle savedInstanceState) {
 
         // try recover presenter via lastNonConfigurationInstance
@@ -147,7 +148,6 @@ public class TiActivityDelegate<P extends TiPresenter<V>, V extends TiView>
                     // this should always work.
                     TiLog.v(mLogTag.getLoggingTag(),
                             "try to recover Presenter with id: " + recoveredPresenterId);
-                    //noinspection unchecked
                     mPresenter = (P) PresenterSavior.INSTANCE.recover(recoveredPresenterId);
                     TiLog.v(mLogTag.getLoggingTag(),
                             "recovered Presenter from savior " + mPresenter);

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiFragmentDelegate.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiFragmentDelegate.java
@@ -101,6 +101,7 @@ public class TiFragmentDelegate<P extends TiPresenter<V>, V extends TiView>
         mViewBinder.invalidateView();
     }
 
+    @SuppressWarnings("unchecked")
     public void onCreate_afterSuper(final Bundle savedInstanceState) {
         if (mPresenter == null && savedInstanceState != null) {
             // recover with Savior
@@ -110,7 +111,6 @@ public class TiFragmentDelegate<P extends TiPresenter<V>, V extends TiView>
             if (recoveredPresenterId != null) {
                 TiLog.v(mLogTag.getLoggingTag(),
                         "try to recover Presenter with id: " + recoveredPresenterId);
-                //noinspection unchecked
                 mPresenter = (P) PresenterSavior.INSTANCE.recover(recoveredPresenterId);
                 if (mPresenter != null) {
                     // save recovered presenter with new id. No other instance of this activity,

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/util/AndroidDeveloperOptions.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/util/AndroidDeveloperOptions.java
@@ -25,6 +25,7 @@ public class AndroidDeveloperOptions {
      * Returns the state of the "Don't keep activities - Destroy every activity as soon as the user
      * leaves it" developer option
      */
+    @SuppressWarnings("deprecation")
     public static boolean isDontKeepActivitiesEnabled(final Context context) {
         int alwaysFinishActivitiesInt;
         if (Build.VERSION.SDK_INT >= 17) {


### PR DESCRIPTION
It might be minor, but if you compile the project in a terminal, then you see these warnings
```
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
```

If you enable the Lint rule, then you can find the classes, e.g.
```
/../ThirtyInch/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/callonmainthread/CallOnMainThreadInterceptor.java:53: warning: [unchecked] unchecked cast
        final V wrappedView = (V) Proxy.newProxyInstance(
                                                        ^
  required: V
  found:    Object
  where V is a type-variable:
    V extends TiView declared in method <V>wrap(V)
```

Problem is that unchecked casts are only suppressed by a comment. IntelliJ recognizes the comment, but not the Java compiler. That's why it's better to suppress those warnings with an annotation. 