### PR TITLE
Fix manageViewSubcription when there isn't any view attached

### DIFF
--- a/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterSubscriptionHandler.java
+++ b/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterSubscriptionHandler.java
@@ -41,7 +41,9 @@ public class RxTiPresenterSubscriptionHandler {
                     if (mUiSubscriptions != null) {
                         mUiSubscriptions.unsubscribe();
                     }
-                    // there is no reuse possible. recreation works fine
+                }
+
+                if (state == TiPresenter.State.VIEW_ATTACHED) {
                     mUiSubscriptions = new CompositeSubscription();
                 }
 

--- a/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterSubscriptionHandler.java
+++ b/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterSubscriptionHandler.java
@@ -36,14 +36,15 @@ public class RxTiPresenterSubscriptionHandler {
             public void onChange(final TiPresenter.State state,
                     final boolean beforeLifecycleEvent) {
                 if (state == TiPresenter.State.VIEW_DETACHED && beforeLifecycleEvent) {
-                    // unsubscribe all UI subscriptions created in wakeUp() and added
+                    // unsubscribe all UI subscriptions created in onAttachView() and added
                     // via manageViewSubscription(Subscription)
                     if (mUiSubscriptions != null) {
                         mUiSubscriptions.unsubscribe();
+                        mUiSubscriptions = null;
                     }
                 }
 
-                if (state == TiPresenter.State.VIEW_ATTACHED) {
+                if (state == TiPresenter.State.VIEW_ATTACHED && beforeLifecycleEvent) {
                     mUiSubscriptions = new CompositeSubscription();
                 }
 

--- a/rx/src/test/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterSubscriptionHandlerTest.java
+++ b/rx/src/test/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterSubscriptionHandlerTest.java
@@ -92,20 +92,6 @@ public class RxTiPresenterSubscriptionHandlerTest {
     }
 
     @Test
-    public void testManageViewSubscription_DetachBeforeAttach_ShouldThrowIllegalStateException()
-            throws Exception {
-        mPresenter.create();
-        TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
-
-        try {
-            mSubscriptionHandler.manageViewSubscription(testSubscriber);
-            fail("no exception");
-        } catch (Exception e) {
-            assertThat(e.getMessage(), containsString("when there is no view"));
-        }
-    }
-
-    @Test
     public void testManageViewSubscription_WithDetachSingleSub_ShouldUnsubscribe()
             throws Exception {
         mPresenter.create();
@@ -129,6 +115,37 @@ public class RxTiPresenterSubscriptionHandlerTest {
         mPresenter.detachView();
 
         testSubscriber.assertUnsubscribed();
+    }
+
+    @Test
+    public void testManageViewSubscription_manageBeforeViewAttached_ShouldThrowIllegalStateException()
+            throws Exception {
+        mPresenter.create();
+        TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
+
+        try {
+            mSubscriptionHandler.manageViewSubscription(testSubscriber);
+            fail("no exception");
+        } catch (Exception e) {
+            assertThat(e.getMessage(), containsString("when there is no view"));
+        }
+    }
+
+    @Test
+    public void testManageViewSubscription_manageAfterDetach_ShouldThrowIllegalStateException()
+            throws Exception {
+        mPresenter.create();
+        mPresenter.attachView(mView);
+        mPresenter.detachView();
+
+        TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
+
+        try {
+            mSubscriptionHandler.manageViewSubscription(testSubscriber);
+            fail("no exception");
+        } catch (Exception e) {
+            assertThat(e.getMessage(), containsString("when there is no view"));
+        }
     }
 
     @Test

--- a/rx/src/test/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterSubscriptionHandlerTest.java
+++ b/rx/src/test/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterSubscriptionHandlerTest.java
@@ -91,16 +91,17 @@ public class RxTiPresenterSubscriptionHandlerTest {
         testSubscriber.assertUnsubscribed();
     }
 
-    @Test(expected = AssertionError.class)
-    public void testManageViewSubscription_DetachBeforeAttach_ShouldThrowAssertError()
+    @Test
+    public void testManageViewSubscription_DetachBeforeAttach_ShouldThrowIllegalStateException()
             throws Exception {
         mPresenter.create();
         TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
 
-        mSubscriptionHandler.manageViewSubscription(testSubscriber);
-        mPresenter.detachView();
-
-        testSubscriber.assertUnsubscribed();
+        try {
+            mSubscriptionHandler.manageViewSubscription(testSubscriber);
+        } catch (Exception e) {
+            assertThat(e.getMessage(), containsString("when there is no view"));
+        }
     }
 
     @Test

--- a/rx/src/test/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterSubscriptionHandlerTest.java
+++ b/rx/src/test/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterSubscriptionHandlerTest.java
@@ -99,6 +99,7 @@ public class RxTiPresenterSubscriptionHandlerTest {
 
         try {
             mSubscriptionHandler.manageViewSubscription(testSubscriber);
+            fail("no exception");
         } catch (Exception e) {
             assertThat(e.getMessage(), containsString("when there is no view"));
         }


### PR DESCRIPTION
I found a strange behaviour during my implementation of #54 (and the follow up issue #55 (2)).
We can actually send a `viewSubscription` to the SubscriptionHandler even when there isn't any view attached.

This PR will fix that issue.