### PR TITLE
Bugfix - Lifecycleobserver and RxHandler*

### DIFF
--- a/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterSubscriptionHandler.java
+++ b/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterSubscriptionHandler.java
@@ -34,8 +34,8 @@ public class RxTiPresenterSubscriptionHandler {
         presenter.addLifecycleObserver(new TiLifecycleObserver() {
             @Override
             public void onChange(final TiPresenter.State state,
-                    final boolean beforeLifecycleEvent) {
-                if (state == TiPresenter.State.VIEW_DETACHED && beforeLifecycleEvent) {
+                    final boolean hasLifecycleMethodBeenCalled) {
+                if (state == TiPresenter.State.VIEW_DETACHED && hasLifecycleMethodBeenCalled) {
                     // unsubscribe all UI subscriptions created in onAttachView() and added
                     // via manageViewSubscription(Subscription)
                     if (mUiSubscriptions != null) {
@@ -44,11 +44,11 @@ public class RxTiPresenterSubscriptionHandler {
                     }
                 }
 
-                if (state == TiPresenter.State.VIEW_ATTACHED && beforeLifecycleEvent) {
+                if (state == TiPresenter.State.VIEW_ATTACHED && hasLifecycleMethodBeenCalled) {
                     mUiSubscriptions = new CompositeSubscription();
                 }
 
-                if (state == TiPresenter.State.DESTROYED && beforeLifecycleEvent) {
+                if (state == TiPresenter.State.DESTROYED && hasLifecycleMethodBeenCalled) {
                     mPresenterSubscriptions.unsubscribe();
                     mPresenterSubscriptions = null;
                 }

--- a/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterSubscriptionHandler.java
+++ b/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterSubscriptionHandler.java
@@ -35,7 +35,7 @@ public class RxTiPresenterSubscriptionHandler {
             @Override
             public void onChange(final TiPresenter.State state,
                     final boolean hasLifecycleMethodBeenCalled) {
-                if (state == TiPresenter.State.VIEW_DETACHED && hasLifecycleMethodBeenCalled) {
+                if (state == TiPresenter.State.VIEW_DETACHED && !hasLifecycleMethodBeenCalled) {
                     // unsubscribe all UI subscriptions created in onAttachView() and added
                     // via manageViewSubscription(Subscription)
                     if (mUiSubscriptions != null) {
@@ -44,11 +44,11 @@ public class RxTiPresenterSubscriptionHandler {
                     }
                 }
 
-                if (state == TiPresenter.State.VIEW_ATTACHED && hasLifecycleMethodBeenCalled) {
+                if (state == TiPresenter.State.VIEW_ATTACHED && !hasLifecycleMethodBeenCalled) {
                     mUiSubscriptions = new CompositeSubscription();
                 }
 
-                if (state == TiPresenter.State.DESTROYED && hasLifecycleMethodBeenCalled) {
+                if (state == TiPresenter.State.DESTROYED && !hasLifecycleMethodBeenCalled) {
                     mPresenterSubscriptions.unsubscribe();
                     mPresenterSubscriptions = null;
                 }

--- a/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterUtils.java
+++ b/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterUtils.java
@@ -127,7 +127,7 @@ public class RxTiPresenterUtils {
                                 .addLifecycleObserver(new TiLifecycleObserver() {
                                     @Override
                                     public void onChange(final TiPresenter.State state,
-                                            final boolean beforeLifecycleEvent) {
+                                            final boolean hasLifecycleMethodBeenCalled) {
                                         if (!subscriber.isUnsubscribed()) {
                                             subscriber.onNext(state
                                                     == TiPresenter.State.VIEW_ATTACHED);

--- a/rx2/src/main/java/net/grandcentrix/thirtyinch/rx2/RxTiPresenterDisposableHandler.java
+++ b/rx2/src/main/java/net/grandcentrix/thirtyinch/rx2/RxTiPresenterDisposableHandler.java
@@ -34,8 +34,8 @@ public class RxTiPresenterDisposableHandler {
         presenter.addLifecycleObserver(new TiLifecycleObserver() {
             @Override
             public void onChange(final TiPresenter.State state,
-                    final boolean beforeLifecycleEvent) {
-                if (state == TiPresenter.State.VIEW_DETACHED && beforeLifecycleEvent) {
+                    final boolean hasLifecycleMethodBeenCalled) {
+                if (state == TiPresenter.State.VIEW_DETACHED && hasLifecycleMethodBeenCalled) {
                     // dispose all UI disposable created in onAttachView(TiView) and added
                     // via manageViewDisposable(Disposable...)
                     if (mUiDisposables != null) {
@@ -44,11 +44,11 @@ public class RxTiPresenterDisposableHandler {
                     }
                 }
 
-                if (state == TiPresenter.State.VIEW_ATTACHED && beforeLifecycleEvent) {
+                if (state == TiPresenter.State.VIEW_ATTACHED && hasLifecycleMethodBeenCalled) {
                     mUiDisposables = new CompositeDisposable();
                 }
 
-                if (state == TiPresenter.State.DESTROYED && beforeLifecycleEvent) {
+                if (state == TiPresenter.State.DESTROYED && hasLifecycleMethodBeenCalled) {
                     mPresenterDisposables.dispose();
                     mPresenterDisposables = null;
                 }

--- a/rx2/src/main/java/net/grandcentrix/thirtyinch/rx2/RxTiPresenterDisposableHandler.java
+++ b/rx2/src/main/java/net/grandcentrix/thirtyinch/rx2/RxTiPresenterDisposableHandler.java
@@ -35,7 +35,7 @@ public class RxTiPresenterDisposableHandler {
             @Override
             public void onChange(final TiPresenter.State state,
                     final boolean hasLifecycleMethodBeenCalled) {
-                if (state == TiPresenter.State.VIEW_DETACHED && hasLifecycleMethodBeenCalled) {
+                if (state == TiPresenter.State.VIEW_DETACHED && !hasLifecycleMethodBeenCalled) {
                     // dispose all UI disposable created in onAttachView(TiView) and added
                     // via manageViewDisposable(Disposable...)
                     if (mUiDisposables != null) {
@@ -44,11 +44,11 @@ public class RxTiPresenterDisposableHandler {
                     }
                 }
 
-                if (state == TiPresenter.State.VIEW_ATTACHED && hasLifecycleMethodBeenCalled) {
+                if (state == TiPresenter.State.VIEW_ATTACHED && !hasLifecycleMethodBeenCalled) {
                     mUiDisposables = new CompositeDisposable();
                 }
 
-                if (state == TiPresenter.State.DESTROYED && hasLifecycleMethodBeenCalled) {
+                if (state == TiPresenter.State.DESTROYED && !hasLifecycleMethodBeenCalled) {
                     mPresenterDisposables.dispose();
                     mPresenterDisposables = null;
                 }

--- a/rx2/src/main/java/net/grandcentrix/thirtyinch/rx2/RxTiPresenterUtils.java
+++ b/rx2/src/main/java/net/grandcentrix/thirtyinch/rx2/RxTiPresenterUtils.java
@@ -46,7 +46,7 @@ public class RxTiPresenterUtils {
                                 .addLifecycleObserver(new TiLifecycleObserver() {
                                     @Override
                                     public void onChange(final TiPresenter.State state,
-                                            final boolean beforeLifecycleEvent) {
+                                            final boolean hasLifecycleMethodBeenCalled) {
                                         if (!emitter.isDisposed()) {
                                             emitter.onNext(state ==
                                                     TiPresenter.State.VIEW_ATTACHED);

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiLifecycleObserver.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiLifecycleObserver.java
@@ -24,9 +24,13 @@ public interface TiLifecycleObserver {
     /**
      * gets called when the {@link net.grandcentrix.thirtyinch.TiPresenter.State} changes
      *
-     * @param state                the new state of the {@link TiPresenter}
-     * @param beforeLifecycleEvent {@code true} when called before the {@code on...} lifecycle
-     *                             methods, {@code false} when called after
+     * @param state                        the new state of the {@link TiPresenter}
+     * @param hasLifecycleMethodBeenCalled {@code false} when called before the {@code on...}
+     *                                     lifecycle methods, {@code true} when called after
+     * @see TiPresenter#onCreate()
+     * @see TiPresenter#onAttachView(TiView)
+     * @see TiPresenter#onDetachView()
+     * @see TiPresenter#onDestroy()
      */
-    void onChange(final TiPresenter.State state, final boolean beforeLifecycleEvent);
+    void onChange(final TiPresenter.State state, final boolean hasLifecycleMethodBeenCalled);
 }

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/TiLifecycleObserverTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/TiLifecycleObserverTest.java
@@ -57,8 +57,8 @@ public class TiLifecycleObserverTest {
         mPresenter.addLifecycleObserver(new TiLifecycleObserver() {
             @Override
             public void onChange(final TiPresenter.State state,
-                    final boolean beforeLifecycleEvent) {
-                states.add(new Object[]{state, beforeLifecycleEvent});
+                    final boolean hasLifecycleMethodBeenCalled) {
+                states.add(new Object[]{state, hasLifecycleMethodBeenCalled});
             }
         });
 
@@ -79,8 +79,8 @@ public class TiLifecycleObserverTest {
         mPresenter.addLifecycleObserver(new TiLifecycleObserver() {
             @Override
             public void onChange(final TiPresenter.State state,
-                    final boolean beforeLifecycleEvent) {
-                states.add(new Object[]{state, beforeLifecycleEvent});
+                    final boolean hasLifecycleMethodBeenCalled) {
+                states.add(new Object[]{state, hasLifecycleMethodBeenCalled});
             }
         });
 
@@ -104,8 +104,8 @@ public class TiLifecycleObserverTest {
         final Removable removable = mPresenter.addLifecycleObserver(new TiLifecycleObserver() {
             @Override
             public void onChange(final TiPresenter.State state,
-                    final boolean beforeLifecycleEvent) {
-                states.add(new Object[]{state, beforeLifecycleEvent});
+                    final boolean hasLifecycleMethodBeenCalled) {
+                states.add(new Object[]{state, hasLifecycleMethodBeenCalled});
             }
         });
 
@@ -136,8 +136,8 @@ public class TiLifecycleObserverTest {
         final TiLifecycleObserver observer = new TiLifecycleObserver() {
             @Override
             public void onChange(final TiPresenter.State state,
-                    final boolean beforeLifecycleEvent) {
-                states.add(new Object[]{state, beforeLifecycleEvent});
+                    final boolean hasLifecycleMethodBeenCalled) {
+                states.add(new Object[]{state, hasLifecycleMethodBeenCalled});
             }
         };
 
@@ -161,8 +161,8 @@ public class TiLifecycleObserverTest {
         mPresenter.addLifecycleObserver(new TiLifecycleObserver() {
             @Override
             public void onChange(final TiPresenter.State state,
-                    final boolean beforeLifecycleEvent) {
-                states.add(new Object[]{state, beforeLifecycleEvent, mPresenter.getView()});
+                    final boolean hasLifecycleMethodBeenCalled) {
+                states.add(new Object[]{state, hasLifecycleMethodBeenCalled, mPresenter.getView()});
             }
         });
 
@@ -187,8 +187,8 @@ public class TiLifecycleObserverTest {
         mPresenter.addLifecycleObserver(new TiLifecycleObserver() {
             @Override
             public void onChange(final TiPresenter.State state,
-                    final boolean beforeLifecycleEvent) {
-                states.add(new Object[]{state, beforeLifecycleEvent, mPresenter.getView()});
+                    final boolean hasLifecycleMethodBeenCalled) {
+                states.add(new Object[]{state, hasLifecycleMethodBeenCalled, mPresenter.getView()});
             }
         });
 


### PR DESCRIPTION
**Given:** : 🌮
Our sample is broken.
It through a `IllegalStateException: view subscriptions can't be handled when there is no view`.
This cames from `RxTiPresenterSubscriptionHandler.manageViewSubscription` which is called from the `HelloWorldPresenter#onAttachView(view)`

But: Why it says that there isn't any view, when onAttachView is called? 🤔

**Reson:** ❌
After a quick reseach the reason is simple:
We introduced such a exception with #58 .
So this is working like expected.
But: Why is is thrown on `onAttachView`?
Because of the `TiLifecycleObserver`. The documentation says:
> /**
     * gets called when the {@link net.grandcentrix.thirtyinch.TiPresenter.State} changes
     *
     * @param state                the new state of the {@link TiPresenter}
     * @param beforeLifecycleEvent {@code true} when called before the {@code on...} lifecycle
     *                             methods, {@code false} when called after
     */

`beforeLifecycleEvent` is wrong here.
If we take a look into the implementation in `TiPresenter#attachView` we see the following:
```java
moveToState(State.VIEW_ATTACHED, false);
// Stuff
onAttachView(view);
// More stuff
moveToState(State.VIEW_ATTACHED, true);
```
The second parameter here indicates if the `on*` method is already called.
Which is wrong according to the documentation of the `TiLifecycleObserver`.

**The fix:** 💚
Because we have already implementations with the `TiLifecycleObserver` I've just changed the documentation (and a better boolean name 😉)

I've also fixed the implementation of the `RxTiPresenter*Handler`.. which have thrown the exception...