### PR TITLE
TiPresenter#runOnUiThread(Runnable)

### DIFF
--- a/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiActivityPlugin.java
+++ b/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiActivityPlugin.java
@@ -29,6 +29,7 @@ import net.grandcentrix.thirtyinch.internal.TiActivityDelegate;
 import net.grandcentrix.thirtyinch.internal.TiLoggingTagProvider;
 import net.grandcentrix.thirtyinch.internal.TiPresenterProvider;
 import net.grandcentrix.thirtyinch.internal.TiViewProvider;
+import net.grandcentrix.thirtyinch.internal.UiThreadExecutor;
 import net.grandcentrix.thirtyinch.util.AndroidDeveloperOptions;
 import net.grandcentrix.thirtyinch.util.AnnotationUtil;
 
@@ -39,6 +40,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import java.util.List;
+import java.util.concurrent.Executor;
 
 /**
  * Binds a {@link TiPresenter} to an {@link Activity}
@@ -118,6 +120,11 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
         return null;
     }
 
+    @Override
+    public Executor getUiThreadExecutor() {
+        return new UiThreadExecutor();
+    }
+
     /**
      * Invalidates the cache of the latest bound view. Forces the next binding of the view to run
      * through all the interceptors (again).
@@ -192,11 +199,6 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
         mDelegate.onStop_beforeSuper();
         super.onStop();
         mDelegate.onStop_afterSuper();
-    }
-
-    @Override
-    public boolean postToMessageQueue(final Runnable runnable) {
-        return getActivity().getWindow().getDecorView().post(runnable);
     }
 
     @SuppressWarnings("unchecked")

--- a/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiActivityPlugin.java
+++ b/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiActivityPlugin.java
@@ -59,6 +59,8 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
 
     private TiActivityDelegate<P, V> mDelegate;
 
+    private final UiThreadExecutor mUiThreadExecutor = new UiThreadExecutor();
+
     /**
      * Binds a {@link TiPresenter} returned by the {@link TiPresenterProvider} to the {@link
      * Activity} and all future {@link Activity} instances created due to configuration changes.
@@ -122,7 +124,7 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
 
     @Override
     public Executor getUiThreadExecutor() {
-        return new UiThreadExecutor();
+        return mUiThreadExecutor;
     }
 
     /**

--- a/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiFragmentPlugin.java
+++ b/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiFragmentPlugin.java
@@ -29,6 +29,7 @@ import net.grandcentrix.thirtyinch.internal.TiFragmentDelegate;
 import net.grandcentrix.thirtyinch.internal.TiLoggingTagProvider;
 import net.grandcentrix.thirtyinch.internal.TiPresenterProvider;
 import net.grandcentrix.thirtyinch.internal.TiViewProvider;
+import net.grandcentrix.thirtyinch.internal.UiThreadExecutor;
 import net.grandcentrix.thirtyinch.util.AndroidDeveloperOptions;
 import net.grandcentrix.thirtyinch.util.AnnotationUtil;
 
@@ -41,6 +42,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import java.util.List;
+import java.util.concurrent.Executor;
 
 /**
  * Adds a {@link TiPresenter} to a Fragment. Can be used for both, {@link Fragment} and
@@ -99,7 +101,6 @@ public class TiFragmentPlugin<P extends TiPresenter<V>, V extends TiView> extend
         return mDelegate.getInterceptors(predicate);
     }
 
-
     @Override
     public String getLoggingTag() {
         return TAG;
@@ -107,6 +108,11 @@ public class TiFragmentPlugin<P extends TiPresenter<V>, V extends TiView> extend
 
     public P getPresenter() {
         return mDelegate.getPresenter();
+    }
+
+    @Override
+    public Executor getUiThreadExecutor() {
+        return new UiThreadExecutor();
     }
 
     /**
@@ -185,11 +191,6 @@ public class TiFragmentPlugin<P extends TiPresenter<V>, V extends TiView> extend
     public void onStop() {
         mDelegate.onStop_beforeSuper();
         super.onStop();
-    }
-
-    @Override
-    public boolean postToMessageQueue(final Runnable runnable) {
-        return getFragment().getActivity().getWindow().getDecorView().post(runnable);
     }
 
     /**

--- a/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiFragmentPlugin.java
+++ b/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiFragmentPlugin.java
@@ -60,6 +60,8 @@ public class TiFragmentPlugin<P extends TiPresenter<V>, V extends TiView> extend
 
     private TiFragmentDelegate<P, V> mDelegate;
 
+    private final UiThreadExecutor mUiThreadExecutor = new UiThreadExecutor();
+
     /**
      * Binds a {@link TiPresenter} returned by the {@link TiPresenterProvider} to the {@link
      * Fragment} and all future {@link Fragment} instances created due to configuration changes.
@@ -112,7 +114,7 @@ public class TiFragmentPlugin<P extends TiPresenter<V>, V extends TiView> extend
 
     @Override
     public Executor getUiThreadExecutor() {
-        return new UiThreadExecutor();
+        return mUiThreadExecutor;
     }
 
     /**

--- a/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterUtils.java
+++ b/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterUtils.java
@@ -114,40 +114,37 @@ public class RxTiPresenterUtils {
      * TiPresenter#attachView(TiView)} and before calling {@link TiPresenter#detachView()}.
      */
     public static Observable<Boolean> isViewReady(final TiPresenter presenter) {
-        return Observable.create(
-                new Observable.OnSubscribe<Boolean>() {
-                    @Override
-                    public void call(final Subscriber<? super Boolean> subscriber) {
-                        if (!subscriber.isUnsubscribed()) {
-                            subscriber.onNext(presenter.getState()
-                                    == TiPresenter.State.VIEW_ATTACHED);
-                        }
+        return Observable.create(new Observable.OnSubscribe<Boolean>() {
+            @Override
+            public void call(final Subscriber<? super Boolean> subscriber) {
+                if (!subscriber.isUnsubscribed()) {
+                    subscriber.onNext(presenter.getState() == TiPresenter.State.VIEW_ATTACHED);
+                }
 
-                        final Removable removable = presenter
-                                .addLifecycleObserver(new TiLifecycleObserver() {
-                                    @Override
-                                    public void onChange(final TiPresenter.State state,
-                                            final boolean hasLifecycleMethodBeenCalled) {
-                                        if (!subscriber.isUnsubscribed()) {
-                                            subscriber.onNext(state
-                                                    == TiPresenter.State.VIEW_ATTACHED);
-                                        }
-                                    }
-                                });
-
-                        subscriber.add(new Subscription() {
+                final Removable removable = presenter
+                        .addLifecycleObserver(new TiLifecycleObserver() {
                             @Override
-                            public boolean isUnsubscribed() {
-                                return removable.isRemoved();
-                            }
-
-                            @Override
-                            public void unsubscribe() {
-                                removable.remove();
+                            public void onChange(final TiPresenter.State state,
+                                    final boolean hasLifecycleMethodBeenCalled) {
+                                if (!subscriber.isUnsubscribed()) {
+                                    subscriber.onNext(state == TiPresenter.State.VIEW_ATTACHED
+                                            && hasLifecycleMethodBeenCalled);
+                                }
                             }
                         });
+
+                subscriber.add(new Subscription() {
+                    @Override
+                    public boolean isUnsubscribed() {
+                        return removable.isRemoved();
                     }
-                })
-                .distinctUntilChanged();
+
+                    @Override
+                    public void unsubscribe() {
+                        removable.remove();
+                    }
+                });
+            }
+        }).distinctUntilChanged();
     }
 }

--- a/rx2/src/main/java/net/grandcentrix/thirtyinch/rx2/RxTiPresenterUtils.java
+++ b/rx2/src/main/java/net/grandcentrix/thirtyinch/rx2/RxTiPresenterUtils.java
@@ -32,42 +32,39 @@ public class RxTiPresenterUtils {
      * TiPresenter#attachView(TiView)} and before calling {@link TiPresenter#detachView()}.
      */
     public static Observable<Boolean> isViewReady(final TiPresenter presenter) {
-        return Observable.create(
-                new ObservableOnSubscribe<Boolean>() {
-                    @Override
-                    public void subscribe(final ObservableEmitter<Boolean> emitter)
-                            throws Exception {
-                        if (!emitter.isDisposed()) {
-                            emitter.onNext(presenter.getState()
-                                    == TiPresenter.State.VIEW_ATTACHED);
-                        }
+        return Observable.create(new ObservableOnSubscribe<Boolean>() {
+            @Override
+            public void subscribe(final ObservableEmitter<Boolean> emitter)
+                    throws Exception {
+                if (!emitter.isDisposed()) {
+                    emitter.onNext(presenter.getState() == TiPresenter.State.VIEW_ATTACHED);
+                }
 
-                        final Removable removable = presenter
-                                .addLifecycleObserver(new TiLifecycleObserver() {
-                                    @Override
-                                    public void onChange(final TiPresenter.State state,
-                                            final boolean hasLifecycleMethodBeenCalled) {
-                                        if (!emitter.isDisposed()) {
-                                            emitter.onNext(state ==
-                                                    TiPresenter.State.VIEW_ATTACHED);
-                                        }
-                                    }
-                                });
-
-                        emitter.setDisposable(new Disposable() {
+                final Removable removable = presenter
+                        .addLifecycleObserver(new TiLifecycleObserver() {
                             @Override
-                            public void dispose() {
-                                removable.remove();
-                            }
-
-                            @Override
-                            public boolean isDisposed() {
-                                return removable.isRemoved();
+                            public void onChange(final TiPresenter.State state,
+                                    final boolean hasLifecycleMethodBeenCalled) {
+                                if (!emitter.isDisposed()) {
+                                    emitter.onNext(state == TiPresenter.State.VIEW_ATTACHED
+                                            && hasLifecycleMethodBeenCalled);
+                                }
                             }
                         });
+
+                emitter.setDisposable(new Disposable() {
+                    @Override
+                    public void dispose() {
+                        removable.remove();
                     }
-                })
-                .distinctUntilChanged();
+
+                    @Override
+                    public boolean isDisposed() {
+                        return removable.isRemoved();
+                    }
+                });
+            }
+        }).distinctUntilChanged();
     }
 
 }

--- a/sample/src/main/java/net/grandcentrix/thirtyinch/sample/HelloWorldPresenter.java
+++ b/sample/src/main/java/net/grandcentrix/thirtyinch/sample/HelloWorldPresenter.java
@@ -16,6 +16,7 @@
 package net.grandcentrix.thirtyinch.sample;
 
 import net.grandcentrix.thirtyinch.TiPresenter;
+import net.grandcentrix.thirtyinch.ViewAction;
 import net.grandcentrix.thirtyinch.rx.RxTiPresenterSubscriptionHandler;
 import net.grandcentrix.thirtyinch.rx.RxTiPresenterUtils;
 
@@ -73,7 +74,12 @@ public class HelloWorldPresenter extends TiPresenter<HelloWorldView> {
                 .subscribe(new Action1<Long>() {
                     @Override
                     public void call(final Long uptime) {
-                        getView().showPresenterUpTime(uptime);
+                        sendToView(new ViewAction<HelloWorldView>() {
+                            @Override
+                            public void call(final HelloWorldView view) {
+                                view.showPresenterUpTime(uptime);
+                            }
+                        });
                     }
                 }));
 

--- a/sample/src/main/java/net/grandcentrix/thirtyinch/sample/HelloWorldView.java
+++ b/sample/src/main/java/net/grandcentrix/thirtyinch/sample/HelloWorldView.java
@@ -25,7 +25,6 @@ public interface HelloWorldView extends TiView {
 
     Observable<Void> onButtonClicked();
 
-    @CallOnMainThread
     void showPresenterUpTime(Long uptime);
 
     @CallOnMainThread

--- a/test/src/main/java/net/grandcentrix/thirtyinch/test/TiPresenterInstructor.java
+++ b/test/src/main/java/net/grandcentrix/thirtyinch/test/TiPresenterInstructor.java
@@ -18,6 +18,8 @@ package net.grandcentrix.thirtyinch.test;
 import net.grandcentrix.thirtyinch.TiPresenter;
 import net.grandcentrix.thirtyinch.TiView;
 
+import java.util.concurrent.Executor;
+
 public class TiPresenterInstructor<V extends TiView> {
 
     private TiPresenter<V> mPresenter;
@@ -32,6 +34,12 @@ public class TiPresenterInstructor<V extends TiView> {
     public void attachView(final V view) {
         detachView();
 
+        mPresenter.setUiThreadExecutor(new Executor() {
+            @Override
+            public void execute(final Runnable action) {
+                action.run();
+            }
+        });
         mPresenter.attachView(view);
     }
 
@@ -59,6 +67,7 @@ public class TiPresenterInstructor<V extends TiView> {
                 break;
             case VIEW_ATTACHED:
                 mPresenter.detachView();
+                mPresenter.setUiThreadExecutor(null);
                 break;
             case DESTROYED:
                 throw new IllegalStateException(

--- a/thirtyinch/src/androidTest/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegateTest.java
+++ b/thirtyinch/src/androidTest/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegateTest.java
@@ -29,6 +29,8 @@ import android.support.annotation.Nullable;
 import android.support.test.runner.AndroidJUnit4;
 import android.test.suitebuilder.annotation.SmallTest;
 
+import java.util.concurrent.Executor;
+
 import static junit.framework.Assert.assertEquals;
 
 @RunWith(AndroidJUnit4.class)
@@ -239,9 +241,13 @@ public class TiActivityDelegateTest {
                     }
 
                     @Override
-                    public boolean postToMessageQueue(final Runnable action) {
-                        action.run();
-                        return true;
+                    public Executor getUiThreadExecutor() {
+                        return new Executor() {
+                            @Override
+                            public void execute(@NonNull final Runnable action) {
+                                action.run();
+                            }
+                        };
                     }
                 },
                 new TiViewProvider<TiView>() {

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
@@ -50,6 +50,8 @@ public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
     private final TiActivityDelegate<P, V> mDelegate
             = new TiActivityDelegate<>(this, this, this, this);
 
+    private final UiThreadExecutor mUiThreadExecutor = new UiThreadExecutor();
+
     @NonNull
     @Override
     public Removable addBindViewInterceptor(@NonNull final BindViewInterceptor interceptor) {
@@ -94,7 +96,7 @@ public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
 
     @Override
     public Executor getUiThreadExecutor() {
-        return new UiThreadExecutor();
+        return mUiThreadExecutor;
     }
 
     /**

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
@@ -22,6 +22,7 @@ import net.grandcentrix.thirtyinch.internal.TiActivityDelegate;
 import net.grandcentrix.thirtyinch.internal.TiLoggingTagProvider;
 import net.grandcentrix.thirtyinch.internal.TiPresenterProvider;
 import net.grandcentrix.thirtyinch.internal.TiViewProvider;
+import net.grandcentrix.thirtyinch.internal.UiThreadExecutor;
 import net.grandcentrix.thirtyinch.util.AndroidDeveloperOptions;
 import net.grandcentrix.thirtyinch.util.AnnotationUtil;
 
@@ -32,6 +33,7 @@ import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 
 import java.util.List;
+import java.util.concurrent.Executor;
 
 /**
  * Created by pascalwelsch on 9/8/15.
@@ -90,6 +92,11 @@ public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
         return null;
     }
 
+    @Override
+    public Executor getUiThreadExecutor() {
+        return new UiThreadExecutor();
+    }
+
     /**
      * Invalidates the cache of the latest bound view. Forces the next binding of the view to run
      * through all the interceptors (again).
@@ -134,11 +141,6 @@ public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
         }
 
         return null;
-    }
-
-    @Override
-    public boolean postToMessageQueue(final Runnable runnable) {
-        return getWindow().getDecorView().post(runnable);
     }
 
     @SuppressWarnings("unchecked")

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiDialogFragment.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiDialogFragment.java
@@ -21,6 +21,7 @@ import net.grandcentrix.thirtyinch.internal.TiFragmentDelegate;
 import net.grandcentrix.thirtyinch.internal.TiLoggingTagProvider;
 import net.grandcentrix.thirtyinch.internal.TiPresenterProvider;
 import net.grandcentrix.thirtyinch.internal.TiViewProvider;
+import net.grandcentrix.thirtyinch.internal.UiThreadExecutor;
 import net.grandcentrix.thirtyinch.util.AndroidDeveloperOptions;
 import net.grandcentrix.thirtyinch.util.AnnotationUtil;
 
@@ -33,6 +34,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import java.util.List;
+import java.util.concurrent.Executor;
 
 public abstract class TiDialogFragment<P extends TiPresenter<V>, V extends TiView>
         extends AppCompatDialogFragment
@@ -72,6 +74,11 @@ public abstract class TiDialogFragment<P extends TiPresenter<V>, V extends TiVie
 
     public P getPresenter() {
         return mDelegate.getPresenter();
+    }
+
+    @Override
+    public Executor getUiThreadExecutor() {
+        return new UiThreadExecutor();
     }
 
     /**
@@ -150,11 +157,6 @@ public abstract class TiDialogFragment<P extends TiPresenter<V>, V extends TiVie
     public void onStop() {
         mDelegate.onStop_beforeSuper();
         super.onStop();
-    }
-
-    @Override
-    public boolean postToMessageQueue(final Runnable runnable) {
-        return getActivity().getWindow().getDecorView().post(runnable);
     }
 
     /**

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiFragment.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiFragment.java
@@ -21,6 +21,7 @@ import net.grandcentrix.thirtyinch.internal.TiFragmentDelegate;
 import net.grandcentrix.thirtyinch.internal.TiLoggingTagProvider;
 import net.grandcentrix.thirtyinch.internal.TiPresenterProvider;
 import net.grandcentrix.thirtyinch.internal.TiViewProvider;
+import net.grandcentrix.thirtyinch.internal.UiThreadExecutor;
 import net.grandcentrix.thirtyinch.util.AndroidDeveloperOptions;
 import net.grandcentrix.thirtyinch.util.AnnotationUtil;
 
@@ -33,6 +34,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import java.util.List;
+import java.util.concurrent.Executor;
 
 public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView> extends Fragment
         implements DelegatedTiFragment, TiPresenterProvider<P>, TiLoggingTagProvider,
@@ -71,6 +73,11 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView> ext
 
     public P getPresenter() {
         return mDelegate.getPresenter();
+    }
+
+    @Override
+    public Executor getUiThreadExecutor() {
+        return new UiThreadExecutor();
     }
 
     /**
@@ -149,11 +156,6 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView> ext
     public void onStop() {
         mDelegate.onStop_beforeSuper();
         super.onStop();
-    }
-
-    @Override
-    public boolean postToMessageQueue(final Runnable runnable) {
-        return getActivity().getWindow().getDecorView().post(runnable);
     }
 
     /**

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiFragment.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiFragment.java
@@ -47,6 +47,8 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView> ext
     private final TiFragmentDelegate<P, V> mDelegate =
             new TiFragmentDelegate<>(this, this, this, this);
 
+    private final UiThreadExecutor mUiThreadExecutor = new UiThreadExecutor();
+
     @NonNull
     @Override
     public Removable addBindViewInterceptor(@NonNull final BindViewInterceptor interceptor) {
@@ -77,7 +79,7 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView> ext
 
     @Override
     public Executor getUiThreadExecutor() {
-        return new UiThreadExecutor();
+        return mUiThreadExecutor;
     }
 
     /**

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
@@ -28,6 +28,7 @@ import android.support.v4.app.Fragment;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
+import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 
 /**
@@ -88,6 +89,12 @@ public abstract class TiPresenter<V extends TiView> {
     private LinkedBlockingQueue<ViewAction<V>> mPostponedViewActions = new LinkedBlockingQueue<>();
 
     private State mState = State.INITIALIZED;
+
+    /**
+     * Executor for UI operations, must be set by the view implementation
+     */
+    @Nullable
+    private Executor mUiThreadExecutor;
 
     private V mView;
 
@@ -313,6 +320,23 @@ public abstract class TiPresenter<V extends TiView> {
 
     public boolean isViewAttached() {
         return mState == State.VIEW_ATTACHED;
+    }
+
+    public void runOnUiThread(@NonNull final Runnable runnable) {
+        if (mUiThreadExecutor != null) {
+            mUiThreadExecutor.execute(runnable);
+        } else {
+            if (getView() == null) {
+                throw new IllegalStateException("view is not attached, "
+                        + "no executor available to run ui interactions on");
+            } else {
+                throw new IllegalStateException("no ui thread executor available");
+            }
+        }
+    }
+
+    public void setUiThreadExecutor(@Nullable final Executor uiThreadExecutor) {
+        mUiThreadExecutor = uiThreadExecutor;
     }
 
     @Override

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
@@ -116,7 +116,9 @@ public abstract class TiPresenter<V extends TiView> {
     }
 
     /**
-     * Observes the lifecycle state of this presenter.
+     * Observes the lifecycle state of this presenter. Observers get called in order they are
+     * added for constructive events and in reversed order for destructive events. First in, last
+     * out.
      *
      * @param observer called when lifecycle state changes after the lifecycle method such as
      *                 {@link

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
@@ -532,8 +532,20 @@ public abstract class TiPresenter<V extends TiView> {
             mState = newState;
         }
 
-        for (int i = 0; i < mLifecycleObservers.size(); i++) {
-            mLifecycleObservers.get(i).onChange(newState, hasLifecycleMethodBeenCalled);
+        switch (newState) {
+            case INITIALIZED:
+            case VIEW_ATTACHED:
+                for (int i = 0; i < mLifecycleObservers.size(); i++) {
+                    mLifecycleObservers.get(i).onChange(newState, hasLifecycleMethodBeenCalled);
+                }
+                break;
+
+            case VIEW_DETACHED:
+            case DESTROYED:
+                // reverse observer order for teardown events; first in, last out
+                for (int i = mLifecycleObservers.size() - 1; i >= 0; i--) {
+                    mLifecycleObservers.get(i).onChange(newState, hasLifecycleMethodBeenCalled);
+                }
         }
     }
 

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
@@ -327,11 +327,12 @@ public abstract class TiPresenter<V extends TiView> {
     /**
      * Runs the specified action on the UI thread. It only works when a view is attached
      * <p>
-     * When you are looking for a way to execute code when the view is attached have a look
-     * at {@link #sendToView(ViewAction)}
+     * When you are looking for a way to execute code when the view got available in the future
+     * have a look at {@link #sendToView(ViewAction)}
      *
      * @param action the action to run on the UI thread
-     * @throws IllegalStateException when the executor is not available
+     * @throws IllegalStateException when the executor is not available (most likely because the
+     *                               view is not attached)
      */
     public void runOnUiThread(@NonNull final Runnable action) {
         if (mUiThreadExecutor != null) {
@@ -346,6 +347,16 @@ public abstract class TiPresenter<V extends TiView> {
         }
     }
 
+    /**
+     * sets the Executor used for the {@link #runOnUiThread(Runnable)} method.
+     * <p>
+     * This Executor is most likely the {@link net.grandcentrix.thirtyinch.internal.UiThreadExecutor}
+     * posting the work on the Android Main Thread.
+     * When using the {@code TiPresenterInstructor} in your tests an {@link Executor} for the
+     * current {@link Thread} is used, therefore all executed actions run synchronous.
+     *
+     * @param uiThreadExecutor executor for view interactions
+     */
     public void setUiThreadExecutor(@Nullable final Executor uiThreadExecutor) {
         mUiThreadExecutor = uiThreadExecutor;
     }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
@@ -324,9 +324,18 @@ public abstract class TiPresenter<V extends TiView> {
         return mState == State.VIEW_ATTACHED;
     }
 
-    public void runOnUiThread(@NonNull final Runnable runnable) {
+    /**
+     * Runs the specified action on the UI thread. It only works when a view is attached
+     * <p>
+     * When you are looking for a way to execute code when the view is attached have a look
+     * at {@link #sendToView(ViewAction)}
+     *
+     * @param action the action to run on the UI thread
+     * @throws IllegalStateException when the executor is not available
+     */
+    public void runOnUiThread(@NonNull final Runnable action) {
         if (mUiThreadExecutor != null) {
-            mUiThreadExecutor.execute(runnable);
+            mUiThreadExecutor.execute(action);
         } else {
             if (getView() == null) {
                 throw new IllegalStateException("view is not attached, "
@@ -445,7 +454,7 @@ public abstract class TiPresenter<V extends TiView> {
     }
 
     /**
-     * Executes the {@link ViewAction} when the view is available.
+     * Executes the {@link ViewAction} when the view is available on the UI thread.
      * Once a view is attached the actions get called in the same order they have been added.
      * When the view is already attached the action will be executed immediately.
      * <p>

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/DelegatedTiActivity.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/DelegatedTiActivity.java
@@ -19,6 +19,8 @@ import android.app.Activity;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 
+import java.util.concurrent.Executor;
+
 /**
  * This interface, implemented by Activities allows easy testing of the {@link TiActivityDelegate}
  * without mocking Android classes such as {@link Activity}
@@ -31,6 +33,11 @@ public interface DelegatedTiActivity<P> {
      */
     @Nullable
     P getRetainedPresenter();
+
+    /**
+     * @return {@link UiThreadExecutor}
+     */
+    Executor getUiThreadExecutor();
 
     /**
      * @return {@link Activity#isChangingConfigurations()}
@@ -46,9 +53,4 @@ public interface DelegatedTiActivity<P> {
      * @return true when the developer option "Don't keep Activities" is enabled
      */
     boolean isDontKeepActivitiesEnabled();
-
-    /**
-     * Post the runnable on the UI queue
-     */
-    boolean postToMessageQueue(Runnable runnable);
 }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/DelegatedTiFragment.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/DelegatedTiFragment.java
@@ -18,7 +18,14 @@ package net.grandcentrix.thirtyinch.internal;
 import android.app.Activity;
 import android.support.v4.app.Fragment;
 
+import java.util.concurrent.Executor;
+
 public interface DelegatedTiFragment {
+
+    /**
+     * @return {@link UiThreadExecutor}
+     */
+    Executor getUiThreadExecutor();
 
     /**
      * @return true when the developer option "Don't keep Activities" is enabled
@@ -44,11 +51,6 @@ public interface DelegatedTiFragment {
      * @return {@link Activity#isFinishing()}
      */
     boolean isHostingActivityFinishing();
-
-    /**
-     * Post the runnable on the UI queue
-     */
-    boolean postToMessageQueue(Runnable runnable);
 
     /**
      * Call {@link Fragment#setRetainInstance(boolean)}

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegate.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegate.java
@@ -193,7 +193,7 @@ public class TiActivityDelegate<P extends TiPresenter<V>, V extends TiView>
 
         //noinspection unchecked
         final UiThreadExecutorAutoBinder uiThreadAutoBinder =
-                new UiThreadExecutorAutoBinder(mPresenter);
+                new UiThreadExecutorAutoBinder(mPresenter, mTiActivity.getUiThreadExecutor());
 
         // bind ui thread to presenter when view is attached
         mUiThreadBinderRemovable = mPresenter.addLifecycleObserver(uiThreadAutoBinder);
@@ -257,7 +257,8 @@ public class TiActivityDelegate<P extends TiPresenter<V>, V extends TiView>
 
     public void onStart_afterSuper() {
         mActivityStarted = true;
-        mTiActivity.postToMessageQueue(new Runnable() {
+        // post to the UI queue to delay bindView until all queued work has finished
+        mTiActivity.getUiThreadExecutor().execute(new Runnable() {
             @Override
             public void run() {
                 // check if still started. It happens that onStop got already called, specially

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiFragmentDelegate.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiFragmentDelegate.java
@@ -165,7 +165,7 @@ public class TiFragmentDelegate<P extends TiPresenter<V>, V extends TiView>
 
         //noinspection unchecked
         final UiThreadExecutorAutoBinder uiThreadAutoBinder =
-                new UiThreadExecutorAutoBinder(mPresenter);
+                new UiThreadExecutorAutoBinder(mPresenter, mTiFragment.getUiThreadExecutor());
 
         // bind ui thread to presenter when view is attached
         mUiThreadBinderRemovable = mPresenter.addLifecycleObserver(uiThreadAutoBinder);
@@ -235,7 +235,7 @@ public class TiFragmentDelegate<P extends TiPresenter<V>, V extends TiView>
         mActivityStarted = true;
 
         if (isUiPossible()) {
-            mTiFragment.postToMessageQueue(new Runnable() {
+            mTiFragment.getUiThreadExecutor().execute(new Runnable() {
                 @Override
                 public void run() {
                     if (isUiPossible() && mActivityStarted) {

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/UiThreadExecutor.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/UiThreadExecutor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2017 grandcentrix GmbH
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.grandcentrix.thirtyinch.internal;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.support.annotation.NonNull;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Executes work on the UI thread. If the current thread is the UI thread, then the action is
+ * executed immediately. If the current thread is not the UI thread, the action is posted to the
+ * event queue of the UI thread.
+ */
+public class UiThreadExecutor implements Executor {
+
+    private final Handler mHandler = new Handler(Looper.getMainLooper());
+
+    private Thread mUiThread = Looper.getMainLooper().getThread();
+
+    @Override
+    public void execute(@NonNull Runnable command) {
+        if (Thread.currentThread() == mUiThread) {
+            // already on main thread, simply execute
+            command.run();
+        } else {
+            mHandler.post(command);
+        }
+    }
+}

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/UiThreadExecutorAutoBinder.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/UiThreadExecutorAutoBinder.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2017 grandcentrix GmbH
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.grandcentrix.thirtyinch.internal;
+
+import net.grandcentrix.thirtyinch.TiLifecycleObserver;
+import net.grandcentrix.thirtyinch.TiPresenter;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.support.annotation.NonNull;
+
+import java.util.concurrent.Executor;
+
+/**
+ * binds a ui thread executor to the presenter when this view is attached
+ */
+public class UiThreadExecutorAutoBinder implements TiLifecycleObserver {
+
+    private static class UiThreadExecutor implements Executor {
+
+        private final Handler mHandler = new Handler(Looper.getMainLooper());
+
+        @Override
+        public void execute(@NonNull Runnable command) {
+            if (Thread.currentThread() == Looper.getMainLooper().getThread()) {
+                // already on main thread, simply execute
+                command.run();
+            } else {
+                mHandler.post(command);
+            }
+        }
+    }
+
+    private final TiPresenter mPresenter;
+
+    private final UiThreadExecutor mUiThreadExecutor = new UiThreadExecutor();
+
+    public UiThreadExecutorAutoBinder(final TiPresenter presenter) {
+        mPresenter = presenter;
+    }
+
+    @Override
+    public void onChange(final TiPresenter.State state,
+            final boolean hasLifecycleMethodBeenCalled) {
+
+        if (state == TiPresenter.State.VIEW_ATTACHED && !hasLifecycleMethodBeenCalled) {
+            // before super.onAttachView(view)
+            mPresenter.setUiThreadExecutor(mUiThreadExecutor);
+        }
+        if (state == TiPresenter.State.VIEW_DETACHED && hasLifecycleMethodBeenCalled) {
+            // after super.onDetachView()
+            mPresenter.setUiThreadExecutor(null);
+        }
+    }
+}

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/UiThreadExecutorAutoBinder.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/UiThreadExecutorAutoBinder.java
@@ -29,13 +29,20 @@ import java.util.concurrent.Executor;
  */
 public class UiThreadExecutorAutoBinder implements TiLifecycleObserver {
 
+    /**
+     * Executes work on the UI thread. If the current thread is the UI thread, then the action is
+     * executed immediately. If the current thread is not the UI thread, the action is posted to the
+     * event queue of the UI thread.
+     */
     private static class UiThreadExecutor implements Executor {
 
         private final Handler mHandler = new Handler(Looper.getMainLooper());
 
+        private Thread mUiThread = Looper.getMainLooper().getThread();
+
         @Override
         public void execute(@NonNull Runnable command) {
-            if (Thread.currentThread() == Looper.getMainLooper().getThread()) {
+            if (Thread.currentThread() == mUiThread) {
                 // already on main thread, simply execute
                 command.run();
             } else {

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/UiThreadExecutorAutoBinder.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/UiThreadExecutorAutoBinder.java
@@ -18,10 +18,6 @@ package net.grandcentrix.thirtyinch.internal;
 import net.grandcentrix.thirtyinch.TiLifecycleObserver;
 import net.grandcentrix.thirtyinch.TiPresenter;
 
-import android.os.Handler;
-import android.os.Looper;
-import android.support.annotation.NonNull;
-
 import java.util.concurrent.Executor;
 
 /**
@@ -29,34 +25,14 @@ import java.util.concurrent.Executor;
  */
 public class UiThreadExecutorAutoBinder implements TiLifecycleObserver {
 
-    /**
-     * Executes work on the UI thread. If the current thread is the UI thread, then the action is
-     * executed immediately. If the current thread is not the UI thread, the action is posted to the
-     * event queue of the UI thread.
-     */
-    private static class UiThreadExecutor implements Executor {
-
-        private final Handler mHandler = new Handler(Looper.getMainLooper());
-
-        private Thread mUiThread = Looper.getMainLooper().getThread();
-
-        @Override
-        public void execute(@NonNull Runnable command) {
-            if (Thread.currentThread() == mUiThread) {
-                // already on main thread, simply execute
-                command.run();
-            } else {
-                mHandler.post(command);
-            }
-        }
-    }
-
     private final TiPresenter mPresenter;
 
-    private final UiThreadExecutor mUiThreadExecutor = new UiThreadExecutor();
+    private final Executor mUiThreadExecutor;
 
-    public UiThreadExecutorAutoBinder(final TiPresenter presenter) {
+    public UiThreadExecutorAutoBinder(final TiPresenter presenter,
+            final Executor uiThreadExecutor) {
         mPresenter = presenter;
+        mUiThreadExecutor = uiThreadExecutor;
     }
 
     @Override

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/SendToViewTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/SendToViewTest.java
@@ -19,6 +19,8 @@ package net.grandcentrix.thirtyinch;
 import org.junit.Test;
 import org.mockito.InOrder;
 
+import java.util.concurrent.Executor;
+
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -45,6 +47,12 @@ public class SendToViewTest {
     public void sendToViewInOrder() throws Exception {
         final TestPresenter presenter = new TestPresenter();
         presenter.create();
+        presenter.setUiThreadExecutor(new Executor() {
+            @Override
+            public void execute(final Runnable action) {
+                action.run();
+            }
+        });
         assertThat(presenter.getQueuedViewActions()).hasSize(0);
 
         presenter.sendToView(new ViewAction<TestView>() {
@@ -82,6 +90,12 @@ public class SendToViewTest {
     public void viewAttached() throws Exception {
         final TestPresenter presenter = new TestPresenter();
         presenter.create();
+        presenter.setUiThreadExecutor(new Executor() {
+            @Override
+            public void execute(final Runnable action) {
+                action.run();
+            }
+        });
         assertThat(presenter.getQueuedViewActions()).hasSize(0);
 
         final TestView view = mock(TestView.class);
@@ -101,6 +115,12 @@ public class SendToViewTest {
     public void viewDetached() throws Exception {
         final TestPresenter presenter = new TestPresenter();
         presenter.create();
+        presenter.setUiThreadExecutor(new Executor() {
+            @Override
+            public void execute(final Runnable action) {
+                action.run();
+            }
+        });
         assertThat(presenter.getQueuedViewActions()).hasSize(0);
 
         presenter.sendToView(new ViewAction<TestView>() {
@@ -122,6 +142,12 @@ public class SendToViewTest {
     public void viewReceivesNoInteractionsAfterDetaching() throws Exception {
         final TestPresenter presenter = new TestPresenter();
         presenter.create();
+        presenter.setUiThreadExecutor(new Executor() {
+            @Override
+            public void execute(final Runnable action) {
+                action.run();
+            }
+        });
         assertThat(presenter.getQueuedViewActions()).hasSize(0);
 
         final TestView view = mock(TestView.class);
@@ -141,7 +167,6 @@ public class SendToViewTest {
 
         verify(view).doSomething1();
         assertThat(presenter.getQueuedViewActions()).hasSize(0);
-
 
         presenter.detachView();
 

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/TiLifecycleObserverTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/TiLifecycleObserverTest.java
@@ -18,6 +18,7 @@ package net.grandcentrix.thirtyinch;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.InOrder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,6 +26,7 @@ import java.util.List;
 import static junit.framework.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 
 public class TiLifecycleObserverTest {
@@ -49,6 +51,97 @@ public class TiLifecycleObserverTest {
     public void tearDown() throws Exception {
         mPresenter = null;
         mView = null;
+    }
+
+    @Test
+    public void testCalledAttachedInCorrectOrder() throws Exception {
+        mPresenter.create();
+
+        // Given 2 observers
+        final TiLifecycleObserver observer1 = mock(TiLifecycleObserver.class);
+        mPresenter.addLifecycleObserver(observer1);
+        final TiLifecycleObserver observer2 = mock(TiLifecycleObserver.class);
+        mPresenter.addLifecycleObserver(observer2);
+
+        // When a view attaches
+        mPresenter.attachView(mock(TiView.class));
+
+        // Then the last added observer gets called last
+        final InOrder inOrder = inOrder(observer1, observer2);
+        inOrder.verify(observer1).onChange(TiPresenter.State.VIEW_ATTACHED, false);
+        inOrder.verify(observer2).onChange(TiPresenter.State.VIEW_ATTACHED, false);
+
+        inOrder.verify(observer1).onChange(TiPresenter.State.VIEW_ATTACHED, true);
+        inOrder.verify(observer2).onChange(TiPresenter.State.VIEW_ATTACHED, true);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testCalledCreateInCorrectOrder() throws Exception {
+
+        // Given 2 observers
+        final TiLifecycleObserver observer1 = mock(TiLifecycleObserver.class);
+        mPresenter.addLifecycleObserver(observer1);
+        final TiLifecycleObserver observer2 = mock(TiLifecycleObserver.class);
+        mPresenter.addLifecycleObserver(observer2);
+
+        // When the presenter gets created and reached view detached state
+        mPresenter.create();
+
+        // Then the last added observer gets called first because it's a destructive event
+        final InOrder inOrder = inOrder(observer1, observer2);
+        inOrder.verify(observer2).onChange(TiPresenter.State.VIEW_DETACHED, false);
+        inOrder.verify(observer1).onChange(TiPresenter.State.VIEW_DETACHED, false);
+
+        inOrder.verify(observer2).onChange(TiPresenter.State.VIEW_DETACHED, true);
+        inOrder.verify(observer1).onChange(TiPresenter.State.VIEW_DETACHED, true);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testCalledDestroyInCorrectOrder() throws Exception {
+
+        // Given a presenter with 2 added observers
+        mPresenter.create();
+        final TiLifecycleObserver observer1 = mock(TiLifecycleObserver.class);
+        mPresenter.addLifecycleObserver(observer1);
+        final TiLifecycleObserver observer2 = mock(TiLifecycleObserver.class);
+        mPresenter.addLifecycleObserver(observer2);
+
+        // When the presenter gets destroyed
+        mPresenter.destroy();
+
+        // Then the last added observer gets called first
+        final InOrder inOrder = inOrder(observer1, observer2);
+        inOrder.verify(observer2).onChange(TiPresenter.State.DESTROYED, false);
+        inOrder.verify(observer1).onChange(TiPresenter.State.DESTROYED, false);
+
+        inOrder.verify(observer2).onChange(TiPresenter.State.DESTROYED, true);
+        inOrder.verify(observer1).onChange(TiPresenter.State.DESTROYED, true);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void testCalledDetachedInCorrectOrder() throws Exception {
+        mPresenter.create();
+        mPresenter.attachView(mock(TiView.class));
+
+        // Given 2 observers
+        final TiLifecycleObserver observer1 = mock(TiLifecycleObserver.class);
+        mPresenter.addLifecycleObserver(observer1);
+        final TiLifecycleObserver observer2 = mock(TiLifecycleObserver.class);
+        mPresenter.addLifecycleObserver(observer2);
+
+        // When the view detached
+        mPresenter.detachView();
+
+        // Then the last added observer gets called first
+        final InOrder inOrder = inOrder(observer1, observer2);
+        inOrder.verify(observer2).onChange(TiPresenter.State.VIEW_DETACHED, false);
+        inOrder.verify(observer1).onChange(TiPresenter.State.VIEW_DETACHED, false);
+
+        inOrder.verify(observer2).onChange(TiPresenter.State.VIEW_DETACHED, true);
+        inOrder.verify(observer1).onChange(TiPresenter.State.VIEW_DETACHED, true);
     }
 
     @Test

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/TiPresenterTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/TiPresenterTest.java
@@ -21,10 +21,18 @@ import org.junit.Test;
 
 import android.support.annotation.NonNull;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotSame;
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.Mockito.mock;
@@ -272,6 +280,34 @@ public class TiPresenterTest {
     }
 
     @Test
+    public void testMissingUiExecutorAndDetachedView() throws Exception {
+        final TiPresenter<TiView> presenter = new TiPresenter<TiView>() {
+        };
+
+        try {
+            presenter.runOnUiThread(mock(Runnable.class));
+        } catch (IllegalStateException e) {
+            assertThat(e.getMessage(), containsString("view"));
+            assertThat(e.getMessage(), containsString("no executor"));
+        }
+    }
+
+    @Test
+    public void testMissingUiExecutorAttachedView() throws Exception {
+        final TiPresenter<TiView> presenter = new TiPresenter<TiView>() {
+        };
+        presenter.create();
+        presenter.attachView(mock(TiView.class));
+
+        try {
+            presenter.runOnUiThread(mock(Runnable.class));
+        } catch (IllegalStateException e) {
+            assertThat(e.getMessage(), not(containsString("view")));
+            assertThat(e.getMessage(), containsString("no ui thread executor"));
+        }
+    }
+
+    @Test
     public void testOnAttachViewSuperNotCalled() throws Exception {
         TiPresenter<TiView> presenter = new TiPresenter<TiView>() {
 
@@ -309,6 +345,44 @@ public class TiPresenterTest {
     }
 
     @Test
+    public void testRunOnUiExecutor() throws Exception {
+
+        // Given a presenter with executor (single thread)
+        final TiPresenter<TiView> presenter = new TiPresenter<TiView>() {
+        };
+        presenter.create();
+
+        final ExecutorService executor = Executors.newSingleThreadExecutor(new ThreadFactory() {
+            @Override
+            public Thread newThread(final Runnable r) {
+                return new Thread(r, "test ui thread");
+            }
+        });
+        presenter.setUiThreadExecutor(executor);
+        presenter.attachView(mock(TiView.class));
+
+        final Thread testThread = Thread.currentThread();
+
+        // When scheduling work to the UI thread
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        presenter.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                // Then the work gets executed on the correct thread
+                final Thread currentThread = Thread.currentThread();
+                assertNotSame(testThread, currentThread);
+                assertTrue("executed on wrong thread",
+                        "test ui thread".equals(currentThread.getName()));
+                latch.countDown();
+            }
+        });
+
+        // wait a reasonable amount of time for the thread to execute the work
+        latch.await(5, TimeUnit.SECONDS);
+    }
+
+    @Test
     public void testSleepSuperNotCalled() throws Exception {
         TiPresenter<TiView> presenter = new TiPresenter<TiView>() {
             @Override
@@ -335,7 +409,6 @@ public class TiPresenterTest {
         assertThat(mPresenter.toString(), containsString("TiMockPresenter"));
         assertThat(mPresenter.toString(), containsString("{view = Mock for TiView, hashCode: "));
     }
-
 
     @Test
     public void testWakeUpSuperNotCalled() throws Exception {

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegateBuilder.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegateBuilder.java
@@ -21,6 +21,8 @@ import net.grandcentrix.thirtyinch.TiView;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import java.util.concurrent.Executor;
+
 import static org.mockito.Mockito.mock;
 
 public class TiActivityDelegateBuilder {
@@ -60,6 +62,16 @@ public class TiActivityDelegateBuilder {
             }
 
             @Override
+            public Executor getUiThreadExecutor() {
+                return new Executor() {
+                    @Override
+                    public void execute(@NonNull final Runnable action) {
+                        action.run();
+                    }
+                };
+            }
+
+            @Override
             public boolean isActivityChangingConfigurations() {
                 return mIsChangingConfigurations;
             }
@@ -74,11 +86,6 @@ public class TiActivityDelegateBuilder {
                 return mIsDontKeepActivitiesEnabled;
             }
 
-            @Override
-            public boolean postToMessageQueue(final Runnable runnable) {
-                runnable.run();
-                return true;
-            }
         }, new TiViewProvider<TiView>() {
             @NonNull
             @Override


### PR DESCRIPTION
Allows code to run on the UI thread within the `TiPresenter`. This is most likely **not** a method for users of `Ti` but for extensions using the `LifecycleObserver`-API (another PR will follow).

### public API changes
The action of `TiPresenter#sendToView(Runnable action)` will be now be called on the UI thread. Furthermore will those actions be executed after `onAttachView(TiView)` and after all lifecycle observers have been called. This allows preparing the view in `onAttachView(TiView)` for those actions. That way the view should be in a "running" state as if the view was never gone.
For very rare and special cases `TiPresenter#getQueuedViewActions()` can be used to manually execute queued actions. People are creative.

Another change has been made to `RxTiPresenterUtils#isViewReady()` which was firing the ready event before `onAttachView(TiView)` was called. The ready event is now fired after `onAttachView(TiView)`

The execution order of lifecycle obersvers when receiving teardown events has been reversed; following "first in, last out"

### internal changes

The method in `DelegatedTiActivity#postToMessageQueue(Runnable runnable)` has been replaced with `DelegatedTiActivity#Executor getUiThreadExecutor();`, same for the `Fragment` interface. All classes have been adjusted.

---

I think the API changes are not critical and could also be bug fixes preventing rare race conditions.
