### PR TITLE
Add sendToPresenter(p -> {})  analog to sendToView(v -> {})

### DIFF
--- a/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiActivityPlugin.java
+++ b/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiActivityPlugin.java
@@ -19,12 +19,14 @@ import com.pascalwelsch.compositeandroid.activity.ActivityPlugin;
 import com.pascalwelsch.compositeandroid.activity.CompositeNonConfigurationInstance;
 
 import net.grandcentrix.thirtyinch.BindViewInterceptor;
+import net.grandcentrix.thirtyinch.PresenterAction;
 import net.grandcentrix.thirtyinch.Removable;
 import net.grandcentrix.thirtyinch.TiActivity;
 import net.grandcentrix.thirtyinch.TiPresenter;
 import net.grandcentrix.thirtyinch.TiView;
 import net.grandcentrix.thirtyinch.internal.DelegatedTiActivity;
 import net.grandcentrix.thirtyinch.internal.InterceptableViewBinder;
+import net.grandcentrix.thirtyinch.internal.PresenterAccessor;
 import net.grandcentrix.thirtyinch.internal.TiActivityDelegate;
 import net.grandcentrix.thirtyinch.internal.TiLoggingTagProvider;
 import net.grandcentrix.thirtyinch.internal.TiPresenterProvider;
@@ -50,7 +52,7 @@ import java.util.concurrent.Executor;
  */
 public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extends ActivityPlugin
         implements TiViewProvider<V>, DelegatedTiActivity<P>, TiLoggingTagProvider,
-        InterceptableViewBinder<V> {
+        InterceptableViewBinder<V>, PresenterAccessor<P, V> {
 
     public static final String NCI_KEY_PRESENTER = "presenter";
 
@@ -107,6 +109,7 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
         return TAG;
     }
 
+    @Override
     public P getPresenter() {
         return mDelegate.getPresenter();
     }
@@ -224,6 +227,11 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
                 return (V) getActivity();
             }
         }
+    }
+
+    @Override
+    public void sendToPresenter(final PresenterAction<P> action) {
+        mDelegate.sendToPresenter(action);
     }
 
     @Override

--- a/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiFragmentPlugin.java
+++ b/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiFragmentPlugin.java
@@ -19,12 +19,14 @@ package net.grandcentrix.thirtyinch.plugin;
 import com.pascalwelsch.compositeandroid.fragment.FragmentPlugin;
 
 import net.grandcentrix.thirtyinch.BindViewInterceptor;
+import net.grandcentrix.thirtyinch.PresenterAction;
 import net.grandcentrix.thirtyinch.Removable;
 import net.grandcentrix.thirtyinch.TiFragment;
 import net.grandcentrix.thirtyinch.TiPresenter;
 import net.grandcentrix.thirtyinch.TiView;
 import net.grandcentrix.thirtyinch.internal.DelegatedTiFragment;
 import net.grandcentrix.thirtyinch.internal.InterceptableViewBinder;
+import net.grandcentrix.thirtyinch.internal.PresenterAccessor;
 import net.grandcentrix.thirtyinch.internal.TiFragmentDelegate;
 import net.grandcentrix.thirtyinch.internal.TiLoggingTagProvider;
 import net.grandcentrix.thirtyinch.internal.TiPresenterProvider;
@@ -53,7 +55,7 @@ import java.util.concurrent.Executor;
  */
 public class TiFragmentPlugin<P extends TiPresenter<V>, V extends TiView> extends FragmentPlugin
         implements TiViewProvider<V>, DelegatedTiFragment, TiLoggingTagProvider,
-        InterceptableViewBinder<V> {
+        InterceptableViewBinder<V>, PresenterAccessor<P, V> {
 
     private String TAG = this.getClass().getSimpleName()
             + "@" + Integer.toHexString(this.hashCode());
@@ -108,6 +110,7 @@ public class TiFragmentPlugin<P extends TiPresenter<V>, V extends TiView> extend
         return TAG;
     }
 
+    @Override
     public P getPresenter() {
         return mDelegate.getPresenter();
     }
@@ -222,6 +225,11 @@ public class TiFragmentPlugin<P extends TiPresenter<V>, V extends TiView> extend
                 return (V) getFragment();
             }
         }
+    }
+
+    @Override
+    public void sendToPresenter(final PresenterAction<P> action) {
+        mDelegate.sendToPresenter(action);
     }
 
     @Override

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/PresenterAction.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/PresenterAction.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2017 grandcentrix GmbH
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.grandcentrix.thirtyinch;
+
+/**
+ * Action which will be be executed when once a presenter is available
+ */
+public interface PresenterAction<P> {
+
+    void call(P presenter);
+}

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
@@ -17,6 +17,7 @@ package net.grandcentrix.thirtyinch;
 
 import net.grandcentrix.thirtyinch.internal.DelegatedTiActivity;
 import net.grandcentrix.thirtyinch.internal.InterceptableViewBinder;
+import net.grandcentrix.thirtyinch.internal.PresenterAccessor;
 import net.grandcentrix.thirtyinch.internal.PresenterNonConfigurationInstance;
 import net.grandcentrix.thirtyinch.internal.TiActivityDelegate;
 import net.grandcentrix.thirtyinch.internal.TiLoggingTagProvider;
@@ -41,7 +42,7 @@ import java.util.concurrent.Executor;
 public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
         extends AppCompatActivity
         implements TiPresenterProvider<P>, TiViewProvider<V>, DelegatedTiActivity<P>,
-        TiLoggingTagProvider, InterceptableViewBinder<V> {
+        TiLoggingTagProvider, InterceptableViewBinder<V>, PresenterAccessor<P, V> {
 
     private final String TAG = this.getClass().getSimpleName()
             + ":" + TiActivity.class.getSimpleName()
@@ -76,6 +77,11 @@ public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
         return TAG;
     }
 
+    /**
+     * is {@code null} before {@link #onCreate(Bundle)}, use
+     * {@link #sendToPresenter(PresenterAction)} in such cases
+     */
+    @Override
     public P getPresenter() {
         return mDelegate.getPresenter();
     }
@@ -166,6 +172,11 @@ public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
                 return (V) this;
             }
         }
+    }
+
+    @Override
+    public void sendToPresenter(final PresenterAction<P> action) {
+        mDelegate.sendToPresenter(action);
     }
 
     @Override

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiDialogFragment.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiDialogFragment.java
@@ -17,6 +17,7 @@ package net.grandcentrix.thirtyinch;
 
 import net.grandcentrix.thirtyinch.internal.DelegatedTiFragment;
 import net.grandcentrix.thirtyinch.internal.InterceptableViewBinder;
+import net.grandcentrix.thirtyinch.internal.PresenterAccessor;
 import net.grandcentrix.thirtyinch.internal.TiFragmentDelegate;
 import net.grandcentrix.thirtyinch.internal.TiLoggingTagProvider;
 import net.grandcentrix.thirtyinch.internal.TiPresenterProvider;
@@ -39,7 +40,7 @@ import java.util.concurrent.Executor;
 public abstract class TiDialogFragment<P extends TiPresenter<V>, V extends TiView>
         extends AppCompatDialogFragment
         implements DelegatedTiFragment, TiPresenterProvider<P>, TiLoggingTagProvider,
-        TiViewProvider<V>, InterceptableViewBinder<V> {
+        TiViewProvider<V>, InterceptableViewBinder<V>, PresenterAccessor<P, V> {
 
     private final String TAG = this.getClass().getSimpleName()
             + ":" + TiDialogFragment.class.getSimpleName()
@@ -72,6 +73,7 @@ public abstract class TiDialogFragment<P extends TiPresenter<V>, V extends TiVie
         return TAG;
     }
 
+    @Override
     public P getPresenter() {
         return mDelegate.getPresenter();
     }
@@ -186,6 +188,11 @@ public abstract class TiDialogFragment<P extends TiPresenter<V>, V extends TiVie
                 return (V) this;
             }
         }
+    }
+
+    @Override
+    public void sendToPresenter(final PresenterAction<P> action) {
+        mDelegate.sendToPresenter(action);
     }
 
     @Override

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiFragment.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiFragment.java
@@ -17,6 +17,7 @@ package net.grandcentrix.thirtyinch;
 
 import net.grandcentrix.thirtyinch.internal.DelegatedTiFragment;
 import net.grandcentrix.thirtyinch.internal.InterceptableViewBinder;
+import net.grandcentrix.thirtyinch.internal.PresenterAccessor;
 import net.grandcentrix.thirtyinch.internal.TiFragmentDelegate;
 import net.grandcentrix.thirtyinch.internal.TiLoggingTagProvider;
 import net.grandcentrix.thirtyinch.internal.TiPresenterProvider;
@@ -38,7 +39,7 @@ import java.util.concurrent.Executor;
 
 public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView> extends Fragment
         implements DelegatedTiFragment, TiPresenterProvider<P>, TiLoggingTagProvider,
-        TiViewProvider<V>, InterceptableViewBinder<V> {
+        TiViewProvider<V>, InterceptableViewBinder<V>, PresenterAccessor<P, V> {
 
     private final String TAG = this.getClass().getSimpleName()
             + ":" + TiFragment.class.getSimpleName()
@@ -73,6 +74,7 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView> ext
         return TAG;
     }
 
+    @Override
     public P getPresenter() {
         return mDelegate.getPresenter();
     }
@@ -187,6 +189,11 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView> ext
                 return (V) this;
             }
         }
+    }
+
+    @Override
+    public void sendToPresenter(final PresenterAction<P> action) {
+        mDelegate.sendToPresenter(action);
     }
 
     @Override

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/PresenterAccessor.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/PresenterAccessor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2017 grandcentrix GmbH
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.grandcentrix.thirtyinch.internal;
+
+
+import net.grandcentrix.thirtyinch.PresenterAction;
+import net.grandcentrix.thirtyinch.TiPresenter;
+import net.grandcentrix.thirtyinch.TiView;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+
+/**
+ * Gives access to the attached presenter
+ */
+public interface PresenterAccessor<P extends TiPresenter<V>, V extends TiView> {
+
+    /**
+     * @return the attached presenter
+     */
+    P getPresenter();
+
+    /**
+     * Executes the {@link PresenterAction} after the presenter got created or available.
+     * When the presenter is already available ({@code getPresenter() != null}) the
+     * {@link PresenterAction} will be executed immediately.
+     * <p>
+     * This method is very useful for Activity methods like
+     * {@link Activity#onRequestPermissionsResult(int, String[], int[])} or
+     * {@link Activity#onActivityResult(int, int, Intent)}. Both methods can restart the Activity
+     * entirely and cause NPEs because the callbacks get called before
+     * {@link Activity#onCreate(Bundle)} where the presenter gets created or reattached to the
+     * Activity.
+     */
+    void sendToPresenter(final PresenterAction<P> action);
+
+}

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/ActivitySendToPresenterTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/ActivitySendToPresenterTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2017 grandcentrix GmbH
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.grandcentrix.thirtyinch;
+
+
+import net.grandcentrix.thirtyinch.internal.TiActivityDelegate;
+import net.grandcentrix.thirtyinch.internal.TiActivityDelegateBuilder;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class ActivitySendToPresenterTest {
+
+    private class MyPresenter extends TiPresenter<TiView> {
+
+        MyPresenter() {
+            super();
+        }
+
+        public MyPresenter(final TiConfiguration config) {
+            super(config);
+        }
+
+        void doSomething1() {
+
+        }
+
+        void doSomething2() {
+
+        }
+
+        void doSomething3() {
+
+        }
+    }
+
+    @Test
+    public void testSendToPresenterInOrder() throws Exception {
+
+        final MyPresenter presenter = Mockito.spy(new MyPresenter());
+        final TiActivityDelegate<TiPresenter<TiView>, TiView> delegate
+                = new TiActivityDelegateBuilder().setPresenter(presenter).build();
+
+        // presenter not attached yet
+        assertThat(delegate.getPresenter()).isNull();
+        verify(presenter, never()).doSomething1();
+
+        // send action3
+        delegate.sendToPresenter(new PresenterAction<TiPresenter<TiView>>() {
+            @Override
+            public void call(final TiPresenter<TiView> p) {
+                ((MyPresenter) p).doSomething3();
+            }
+        });
+        // send action1
+        delegate.sendToPresenter(new PresenterAction<TiPresenter<TiView>>() {
+            @Override
+            public void call(final TiPresenter<TiView> p) {
+                ((MyPresenter) p).doSomething1();
+            }
+        });
+        // send action2
+        delegate.sendToPresenter(new PresenterAction<TiPresenter<TiView>>() {
+            @Override
+            public void call(final TiPresenter<TiView> p) {
+                ((MyPresenter) p).doSomething2();
+            }
+        });
+
+        // nothing has been executed
+        Mockito.verifyZeroInteractions(presenter);
+
+        // attach presenter
+        delegate.onCreate_afterSuper(null);
+        assertThat(delegate.getPresenter()).isNotNull();
+
+        final InOrder inOrder = inOrder(presenter);
+
+        // automatically executes the actions in order
+        inOrder.verify(presenter, times(1)).doSomething3();
+        inOrder.verify(presenter, times(1)).doSomething1();
+        inOrder.verify(presenter, times(1)).doSomething2();
+
+    }
+
+    @Test
+    public void testSendToPresenter_AfterPresenterIsAttached() throws Exception {
+
+        final MyPresenter presenter = Mockito.spy(new MyPresenter());
+        final TiActivityDelegate<TiPresenter<TiView>, TiView> delegate
+                = new TiActivityDelegateBuilder().setPresenter(presenter).build();
+
+        // attach presenter
+        delegate.onCreate_afterSuper(null);
+        assertThat(delegate.getPresenter()).isNotNull();
+
+        // send action
+        delegate.sendToPresenter(new PresenterAction<TiPresenter<TiView>>() {
+            @Override
+            public void call(final TiPresenter<TiView> p) {
+                ((MyPresenter) p).doSomething1();
+            }
+        });
+
+        // will be executed
+        verify(presenter, times(1)).doSomething1();
+    }
+
+    @Test
+    public void testSendToPresenter_BeforePresenterIsAttached() throws Exception {
+
+        final MyPresenter presenter = Mockito.spy(new MyPresenter());
+        final TiActivityDelegate<TiPresenter<TiView>, TiView> delegate
+                = new TiActivityDelegateBuilder().setPresenter(presenter).build();
+
+        // presenter not attached yet
+        assertThat(delegate.getPresenter()).isNull();
+        verify(presenter, never()).doSomething1();
+
+        // send action
+        delegate.sendToPresenter(new PresenterAction<TiPresenter<TiView>>() {
+            @Override
+            public void call(final TiPresenter<TiView> p) {
+                ((MyPresenter) p).doSomething1();
+            }
+        });
+        // will not be executed
+        verify(presenter, never()).doSomething1();
+
+        // attach presenter
+        delegate.onCreate_afterSuper(null);
+        assertThat(delegate.getPresenter()).isNotNull();
+
+        // automatically executes the action
+        verify(presenter, times(1)).doSomething1();
+    }
+}

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/FragmentSendToPresenterTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/FragmentSendToPresenterTest.java
@@ -16,8 +16,6 @@
 package net.grandcentrix.thirtyinch;
 
 
-import net.grandcentrix.thirtyinch.internal.TiActivityDelegate;
-import net.grandcentrix.thirtyinch.internal.TiActivityDelegateBuilder;
 import net.grandcentrix.thirtyinch.internal.TiFragmentDelegate;
 import net.grandcentrix.thirtyinch.internal.TiFragmentDelegateBuilder;
 
@@ -60,8 +58,8 @@ public class FragmentSendToPresenterTest {
     public void testSendToPresenterInOrder() throws Exception {
 
         final MyPresenter presenter = Mockito.spy(new MyPresenter());
-        final TiActivityDelegate<TiPresenter<TiView>, TiView> delegate
-                = new TiActivityDelegateBuilder().setPresenter(presenter).build();
+        final TiFragmentDelegate<TiPresenter<TiView>, TiView> delegate
+                = new TiFragmentDelegateBuilder().setPresenter(presenter).build();
 
         // presenter not attached yet
         assertThat(delegate.getPresenter()).isNull();
@@ -132,8 +130,8 @@ public class FragmentSendToPresenterTest {
     public void testSendToPresenter_BeforePresenterIsAttached() throws Exception {
 
         final MyPresenter presenter = Mockito.spy(new MyPresenter());
-        final TiActivityDelegate<TiPresenter<TiView>, TiView> delegate
-                = new TiActivityDelegateBuilder().setPresenter(presenter).build();
+        final TiFragmentDelegate<TiPresenter<TiView>, TiView> delegate
+                = new TiFragmentDelegateBuilder().setPresenter(presenter).build();
 
         // presenter not attached yet
         assertThat(delegate.getPresenter()).isNull();

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/FragmentSendToPresenterTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/FragmentSendToPresenterTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2017 grandcentrix GmbH
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.grandcentrix.thirtyinch;
+
+
+import net.grandcentrix.thirtyinch.internal.TiActivityDelegate;
+import net.grandcentrix.thirtyinch.internal.TiActivityDelegateBuilder;
+import net.grandcentrix.thirtyinch.internal.TiFragmentDelegate;
+import net.grandcentrix.thirtyinch.internal.TiFragmentDelegateBuilder;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class FragmentSendToPresenterTest {
+
+    private class MyPresenter extends TiPresenter<TiView> {
+
+        MyPresenter() {
+            super();
+        }
+
+        public MyPresenter(final TiConfiguration config) {
+            super(config);
+        }
+
+        void doSomething1() {
+
+        }
+
+        void doSomething2() {
+
+        }
+
+        void doSomething3() {
+
+        }
+    }
+
+    @Test
+    public void testSendToPresenterInOrder() throws Exception {
+
+        final MyPresenter presenter = Mockito.spy(new MyPresenter());
+        final TiActivityDelegate<TiPresenter<TiView>, TiView> delegate
+                = new TiActivityDelegateBuilder().setPresenter(presenter).build();
+
+        // presenter not attached yet
+        assertThat(delegate.getPresenter()).isNull();
+        verify(presenter, never()).doSomething1();
+
+        // send action3
+        delegate.sendToPresenter(new PresenterAction<TiPresenter<TiView>>() {
+            @Override
+            public void call(final TiPresenter<TiView> p) {
+                ((MyPresenter) p).doSomething3();
+            }
+        });
+        // send action1
+        delegate.sendToPresenter(new PresenterAction<TiPresenter<TiView>>() {
+            @Override
+            public void call(final TiPresenter<TiView> p) {
+                ((MyPresenter) p).doSomething1();
+            }
+        });
+        // send action2
+        delegate.sendToPresenter(new PresenterAction<TiPresenter<TiView>>() {
+            @Override
+            public void call(final TiPresenter<TiView> p) {
+                ((MyPresenter) p).doSomething2();
+            }
+        });
+
+        // nothing has been executed
+        Mockito.verifyZeroInteractions(presenter);
+
+        // attach presenter
+        delegate.onCreate_afterSuper(null);
+        assertThat(delegate.getPresenter()).isNotNull();
+
+        final InOrder inOrder = inOrder(presenter);
+
+        // automatically executes the actions in order
+        inOrder.verify(presenter, times(1)).doSomething3();
+        inOrder.verify(presenter, times(1)).doSomething1();
+        inOrder.verify(presenter, times(1)).doSomething2();
+
+    }
+
+    @Test
+    public void testSendToPresenter_AfterPresenterIsAttached() throws Exception {
+
+        final MyPresenter presenter = Mockito.spy(new MyPresenter());
+        final TiFragmentDelegate<TiPresenter<TiView>, TiView> delegate
+                = new TiFragmentDelegateBuilder().setPresenter(presenter).build();
+
+        // attach presenter
+        delegate.onCreate_afterSuper(null);
+        assertThat(delegate.getPresenter()).isNotNull();
+
+        // send action
+        delegate.sendToPresenter(new PresenterAction<TiPresenter<TiView>>() {
+            @Override
+            public void call(final TiPresenter<TiView> p) {
+                ((MyPresenter) p).doSomething1();
+            }
+        });
+
+        // will be executed
+        verify(presenter, times(1)).doSomething1();
+    }
+
+    @Test
+    public void testSendToPresenter_BeforePresenterIsAttached() throws Exception {
+
+        final MyPresenter presenter = Mockito.spy(new MyPresenter());
+        final TiActivityDelegate<TiPresenter<TiView>, TiView> delegate
+                = new TiActivityDelegateBuilder().setPresenter(presenter).build();
+
+        // presenter not attached yet
+        assertThat(delegate.getPresenter()).isNull();
+        verify(presenter, never()).doSomething1();
+
+        // send action
+        delegate.sendToPresenter(new PresenterAction<TiPresenter<TiView>>() {
+            @Override
+            public void call(final TiPresenter<TiView> p) {
+                ((MyPresenter) p).doSomething1();
+            }
+        });
+        // will not be executed
+        verify(presenter, never()).doSomething1();
+
+        // attach presenter
+        delegate.onCreate_afterSuper(null);
+        assertThat(delegate.getPresenter()).isNotNull();
+
+        // automatically executes the action
+        verify(presenter, times(1)).doSomething1();
+    }
+}

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/TiFragmentDelegateBuilder.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/TiFragmentDelegateBuilder.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2017 grandcentrix GmbH
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.grandcentrix.thirtyinch.internal;
+
+import net.grandcentrix.thirtyinch.TiPresenter;
+import net.grandcentrix.thirtyinch.TiView;
+
+import android.support.annotation.NonNull;
+
+import java.util.concurrent.Executor;
+
+import static org.mockito.Mockito.mock;
+
+public class TiFragmentDelegateBuilder {
+
+    private boolean mIsAdded;
+
+    private boolean mIsChangingConfigurations = false;
+
+    private boolean mIsDetached;
+
+    private boolean mIsDontKeepActivitiesEnabled = false;
+
+    private boolean mIsFinishing = false;
+
+    private TiPresenter<TiView> mPresenter;
+
+    private TiPresenterProvider<TiPresenter<TiView>> mPresenterProvider;
+
+    public TiFragmentDelegate<TiPresenter<TiView>, TiView> build() {
+        TiPresenterProvider<TiPresenter<TiView>> presenterProvider = mPresenterProvider;
+        if (presenterProvider == null) {
+            presenterProvider = new TiPresenterProvider<TiPresenter<TiView>>() {
+                @NonNull
+                @Override
+                public TiPresenter<TiView> providePresenter() {
+                    return mPresenter;
+                }
+            };
+        }
+
+        return new TiFragmentDelegate<>(new DelegatedTiFragment() {
+            @Override
+            public Executor getUiThreadExecutor() {
+                return new Executor() {
+                    @Override
+                    public void execute(@NonNull final Runnable action) {
+                        action.run();
+                    }
+                };
+            }
+
+            @Override
+            public boolean isDontKeepActivitiesEnabled() {
+                return mIsDontKeepActivitiesEnabled;
+            }
+
+            @Override
+            public boolean isFragmentAdded() {
+                return mIsAdded;
+            }
+
+            @Override
+            public boolean isFragmentDetached() {
+                return mIsDetached;
+            }
+
+            @Override
+            public boolean isHostingActivityChangingConfigurations() {
+                return mIsChangingConfigurations;
+            }
+
+            @Override
+            public boolean isHostingActivityFinishing() {
+                return mIsFinishing;
+            }
+
+            @Override
+            public void setFragmentRetainInstance(final boolean retain) {
+                // nothing to do
+            }
+
+        }, new TiViewProvider<TiView>() {
+            @NonNull
+            @Override
+            public TiView provideView() {
+                return mock(TiView.class);
+            }
+        }, presenterProvider, new TiLoggingTagProvider() {
+            @Override
+            public String getLoggingTag() {
+                return "TestLogTag";
+            }
+        });
+    }
+
+    public TiFragmentDelegateBuilder setDontKeepActivitiesEnabled(final boolean enabled) {
+        mIsDontKeepActivitiesEnabled = enabled;
+        return this;
+    }
+
+    public TiFragmentDelegateBuilder setIsAdded(boolean isAdded) {
+        mIsAdded = isAdded;
+        return this;
+    }
+
+    public TiFragmentDelegateBuilder setIsChangingConfigurations(final boolean changing) {
+        mIsChangingConfigurations = changing;
+        return this;
+    }
+
+    public TiFragmentDelegateBuilder setIsDetached(boolean isDetached) {
+        mIsDetached = isDetached;
+        return this;
+    }
+
+    public TiFragmentDelegateBuilder setIsFinishing(final boolean finishing) {
+        mIsFinishing = finishing;
+        return this;
+    }
+
+    public TiFragmentDelegateBuilder setPresenter(TiPresenter<TiView> presenter) {
+        mPresenter = presenter;
+        return this;
+    }
+
+    public TiFragmentDelegateBuilder setPresenterProvider(
+            TiPresenterProvider<TiPresenter<TiView>> provider) {
+        mPresenterProvider = provider;
+        return this;
+    }
+}


### PR DESCRIPTION
Like `sendToView(v -> {})` the new `sendToPresenter(p -> {})` is very useful for permissions and activity results. It can be used in callback methods with can be called **before** `#onCreate(Bundle)`

```java

    @Override
    protected void onActivityResult(final int requestCode, final int resultCode,
            final Intent data) {
        super.onActivityResult(requestCode, resultCode, data);
        sendToPresenter(presenter -> presenter.onResultReceived());
    }
```

issues #30 

I also created an interface `PresenterAccessor` bundling `getPresenter()` and `sendToPresenter { }`. Now all methods in Activities and Fragment implementations use `@Override` everywhere. And we don't miss something