### PR TITLE
Manage*Subcription return Subscription now

### DIFF
--- a/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterSubscriptionHandler.java
+++ b/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterSubscriptionHandler.java
@@ -37,7 +37,7 @@ public class RxTiPresenterSubscriptionHandler {
                     final boolean hasLifecycleMethodBeenCalled) {
                 if (state == TiPresenter.State.VIEW_DETACHED && !hasLifecycleMethodBeenCalled) {
                     // unsubscribe all UI subscriptions created in onAttachView() and added
-                    // via manageViewSubscription(Subscription)
+                    // via manageViewSubscriptions(Subscription)
                     if (mUiSubscriptions != null) {
                         mUiSubscriptions.unsubscribe();
                         mUiSubscriptions = null;
@@ -57,34 +57,65 @@ public class RxTiPresenterSubscriptionHandler {
     }
 
     /**
-     * Add your subscriptions here and they will automatically unsubscribed when
+     * Add your subscription here and they will automatically unsubscribed when
      * {@link TiPresenter#destroy()} gets called
      *
      * @throws IllegalStateException when the presenter has reached {@link net.grandcentrix.thirtyinch.TiPresenter.State#DESTROYED}
+     * @see #manageSubscriptions(Subscription...)
      */
-    public void manageSubscription(@NonNull final Subscription... subscriptions) {
+    public Subscription manageSubscription(@NonNull final Subscription subscription) {
         if (mPresenterSubscriptions == null) {
             throw new IllegalStateException("subscription handling doesn't work"
                     + " when the presenter has reached the DESTROYED state");
         }
 
-        mPresenterSubscriptions.addAll(subscriptions);
+        mPresenterSubscriptions.add(subscription);
+        return subscription;
+    }
+
+    /**
+     * Add your subscriptions here and they will automatically unsubscribed when
+     * {@link TiPresenter#destroy()} gets called
+     *
+     * @throws IllegalStateException when the presenter has reached {@link net.grandcentrix.thirtyinch.TiPresenter.State#DESTROYED}
+     * @see #manageSubscription(Subscription)
+     */
+    public void manageSubscriptions(@NonNull final Subscription... subscriptions) {
+        for (int i = 0; i < subscriptions.length; i++) {
+            manageViewSubscription(subscriptions[i]);
+        }
+    }
+
+    /**
+     * Add your subscription for View events to this method to get them automatically cleaned up
+     * in {@link TiPresenter#detachView()}. Typically call this in
+     * {@link TiPresenter#attachView(TiView)} where you subscribe to the UI events.
+     *
+     * @throws IllegalStateException when no view is attached
+     * @see #manageViewSubscriptions(Subscription...)
+     */
+    public Subscription manageViewSubscription(@NonNull final Subscription subscription) {
+        if (mUiSubscriptions == null) {
+            throw new IllegalStateException("view subscription can't be handled"
+                    + " when there is no view");
+        }
+
+        mUiSubscriptions.add(subscription);
+        return subscription;
     }
 
     /**
      * Add your subscriptions for View events to this method to get them automatically cleaned up
-     * in {@link TiPresenter#detachView()}. typically call this in {@link
-     * TiPresenter#attachView(TiView)} where you subscribe to the UI events.
+     * in {@link TiPresenter#detachView()}. Typically call this in
+     * {@link TiPresenter#attachView(TiView)} where you subscribe to the UI events.
      *
      * @throws IllegalStateException when no view is attached
+     * @see #manageViewSubscription(Subscription)
      */
-    public void manageViewSubscription(@NonNull final Subscription... subscriptions) {
-        if (mUiSubscriptions == null) {
-            throw new IllegalStateException("view subscriptions can't be handled"
-                    + " when there is no view");
+    public void manageViewSubscriptions(@NonNull final Subscription... subscriptions) {
+        for (int i = 0; i < subscriptions.length; i++) {
+            manageViewSubscription(subscriptions[i]);
         }
-
-        mUiSubscriptions.addAll(subscriptions);
     }
 
 }

--- a/rx2/src/main/java/net/grandcentrix/thirtyinch/rx2/RxTiPresenterDisposableHandler.java
+++ b/rx2/src/main/java/net/grandcentrix/thirtyinch/rx2/RxTiPresenterDisposableHandler.java
@@ -58,34 +58,63 @@ public class RxTiPresenterDisposableHandler {
     }
 
     /**
-     * Add your disposables here and they will automatically disposed when
+     * Add your disposable here and they will automatically disposed when
      * {@link TiPresenter#destroy()} gets called
      *
      * @throws IllegalStateException when the presenter has reached {@link net.grandcentrix.thirtyinch.TiPresenter.State#DESTROYED}
      */
-    public void manageDisposable(@NonNull final Disposable... disposables) {
+    public Disposable manageDisposable(@NonNull final Disposable disposable) {
         if (mPresenterDisposables == null) {
             throw new IllegalStateException("disposable handling doesn't work"
                     + " when the presenter has reached the DESTROYED state");
         }
 
-        mPresenterDisposables.addAll(disposables);
+        mPresenterDisposables.add(disposable);
+        return disposable;
+    }
+
+
+    /**
+     * Add your disposables here and they will automatically disposed when
+     * {@link TiPresenter#destroy()} gets called
+     *
+     * @throws IllegalStateException when the presenter has reached {@link net.grandcentrix.thirtyinch.TiPresenter.State#DESTROYED}
+     * @see #manageDisposable(Disposable)
+     */
+    public void manageDisposables(@NonNull final Disposable... disposable) {
+        for (int i = 0; i < disposable.length; i++) {
+            manageDisposable(disposable[i]);
+        }
     }
 
     /**
-     * Add your disposables for View events to this method to get them automatically cleaned up
-     * in {@link TiPresenter#detachView()}. typically call this in {@link
-     * TiPresenter#attachView(TiView)} where you dispose to the UI events.
+     * Add your disposable for View events to this method to get them automatically cleaned up
+     * in {@link TiPresenter#detachView()}. typically call this in
+     * {@link TiPresenter#attachView(TiView)} where you dispose to the UI events.
      *
      * @throws IllegalStateException when no view is attached
      */
-    public void manageViewDisposable(@NonNull final Disposable... disposables) {
+    public Disposable manageViewDisposable(@NonNull final Disposable disposable) {
         if (mUiDisposables == null) {
             throw new IllegalStateException("view disposable can't be handled"
                     + " when there is no view");
         }
 
-        mUiDisposables.addAll(disposables);
+        mUiDisposables.add(disposable);
+        return disposable;
+    }
+
+    /**
+     * Add your disposables for View events to this method to get them automatically cleaned up
+     * in {@link TiPresenter#detachView()}. typically call this in
+     * {@link TiPresenter#attachView(TiView)} where you dispose to the UI events.
+     *
+     * @throws IllegalStateException when no view is attached
+     */
+    public void manageViewDisposables(@NonNull final Disposable... disposables) {
+        for (int i = 0; i < disposables.length; i++) {
+            manageViewDisposable(disposables[i]);
+        }
     }
 
 }

--- a/sample/src/main/java/net/grandcentrix/thirtyinch/sample/HelloWorldPresenter.java
+++ b/sample/src/main/java/net/grandcentrix/thirtyinch/sample/HelloWorldPresenter.java
@@ -24,6 +24,7 @@ import android.support.annotation.NonNull;
 import java.util.concurrent.TimeUnit;
 
 import rx.Observable;
+import rx.Subscription;
 import rx.functions.Func1;
 import rx.schedulers.Schedulers;
 import rx.subjects.BehaviorSubject;
@@ -44,13 +45,13 @@ public class HelloWorldPresenter extends TiPresenter<HelloWorldView> {
     protected void onAttachView(@NonNull final HelloWorldView view) {
         super.onAttachView(view);
 
-        rxSubscriptionHelper.manageViewSubscription(mText.asObservable()
-                .subscribe(view::showText));
-
-        rxSubscriptionHelper.manageViewSubscription(view.onButtonClicked()
+        final Subscription showTextSub = mText.asObservable().subscribe(view::showText);
+        final Subscription onButtonClickSub = view.onButtonClicked()
                 .subscribe(aVoid -> {
                     triggerHeavyCalculation.onNext(null);
-                }));
+                });
+
+        rxSubscriptionHelper.manageViewSubscriptions(showTextSub, onButtonClickSub);
     }
 
     @Override


### PR DESCRIPTION
This will fix #59 

Nothing special here.
`manageViewSubscription/disposable` will now return the given `Subscription/Disposable`.
`manageViewSubscriptions` have introduced to add multiple `Subscription/Disposable`.

That is a small "API change". But only on RC's.
Because in earlier 0.8 RC's we have changed the API from `manageViewSubscription(Subscription)` to `manageViewSubscription(Subscription...)`.
Not we "revertet" it to `manageViewSubscription(Subscription)` but added `manageViewSubscriptions(Subscription...)` (note the `S` here 😉)