### PR TITLE
Make savior injectable into delegates

### DIFF
--- a/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiActivityPlugin.java
+++ b/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiActivityPlugin.java
@@ -25,6 +25,7 @@ import net.grandcentrix.thirtyinch.TiPresenter;
 import net.grandcentrix.thirtyinch.TiView;
 import net.grandcentrix.thirtyinch.internal.DelegatedTiActivity;
 import net.grandcentrix.thirtyinch.internal.InterceptableViewBinder;
+import net.grandcentrix.thirtyinch.internal.PresenterSavior;
 import net.grandcentrix.thirtyinch.internal.TiActivityDelegate;
 import net.grandcentrix.thirtyinch.internal.TiLoggingTagProvider;
 import net.grandcentrix.thirtyinch.internal.TiPresenterProvider;
@@ -73,7 +74,8 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
      * @param presenterProvider callback returning the presenter.
      */
     public TiActivityPlugin(@NonNull final TiPresenterProvider<P> presenterProvider) {
-        mDelegate = new TiActivityDelegate<>(this, this, presenterProvider, this);
+        mDelegate = new TiActivityDelegate<>(this, this, presenterProvider, this,
+                PresenterSavior.INSTANCE);
     }
 
     @NonNull

--- a/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiFragmentPlugin.java
+++ b/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiFragmentPlugin.java
@@ -25,6 +25,7 @@ import net.grandcentrix.thirtyinch.TiPresenter;
 import net.grandcentrix.thirtyinch.TiView;
 import net.grandcentrix.thirtyinch.internal.DelegatedTiFragment;
 import net.grandcentrix.thirtyinch.internal.InterceptableViewBinder;
+import net.grandcentrix.thirtyinch.internal.PresenterSavior;
 import net.grandcentrix.thirtyinch.internal.TiFragmentDelegate;
 import net.grandcentrix.thirtyinch.internal.TiLoggingTagProvider;
 import net.grandcentrix.thirtyinch.internal.TiPresenterProvider;
@@ -74,7 +75,8 @@ public class TiFragmentPlugin<P extends TiPresenter<V>, V extends TiView> extend
      * @param presenterProvider callback returning the presenter.
      */
     public TiFragmentPlugin(@NonNull final TiPresenterProvider<P> presenterProvider) {
-        mDelegate = new TiFragmentDelegate<>(this, this, presenterProvider, this);
+        mDelegate = new TiFragmentDelegate<>(this, this, presenterProvider, this,
+                PresenterSavior.INSTANCE);
     }
 
     @NonNull

--- a/thirtyinch/src/androidTest/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegateTest.java
+++ b/thirtyinch/src/androidTest/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegateTest.java
@@ -270,6 +270,7 @@ public class TiActivityDelegateTest {
                     public String getLoggingTag() {
                         return "TestTag";
                     }
-                });
+                },
+        PresenterSavior.INSTANCE);
     }
 }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
@@ -18,6 +18,7 @@ package net.grandcentrix.thirtyinch;
 import net.grandcentrix.thirtyinch.internal.DelegatedTiActivity;
 import net.grandcentrix.thirtyinch.internal.InterceptableViewBinder;
 import net.grandcentrix.thirtyinch.internal.PresenterNonConfigurationInstance;
+import net.grandcentrix.thirtyinch.internal.PresenterSavior;
 import net.grandcentrix.thirtyinch.internal.TiActivityDelegate;
 import net.grandcentrix.thirtyinch.internal.TiLoggingTagProvider;
 import net.grandcentrix.thirtyinch.internal.TiPresenterProvider;
@@ -48,7 +49,7 @@ public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
             + "@" + Integer.toHexString(this.hashCode());
 
     private final TiActivityDelegate<P, V> mDelegate
-            = new TiActivityDelegate<>(this, this, this, this);
+            = new TiActivityDelegate<>(this, this, this, this, PresenterSavior.INSTANCE);
 
     private final UiThreadExecutor mUiThreadExecutor = new UiThreadExecutor();
 

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiDialogFragment.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiDialogFragment.java
@@ -17,6 +17,7 @@ package net.grandcentrix.thirtyinch;
 
 import net.grandcentrix.thirtyinch.internal.DelegatedTiFragment;
 import net.grandcentrix.thirtyinch.internal.InterceptableViewBinder;
+import net.grandcentrix.thirtyinch.internal.PresenterSavior;
 import net.grandcentrix.thirtyinch.internal.TiFragmentDelegate;
 import net.grandcentrix.thirtyinch.internal.TiLoggingTagProvider;
 import net.grandcentrix.thirtyinch.internal.TiPresenterProvider;
@@ -46,7 +47,7 @@ public abstract class TiDialogFragment<P extends TiPresenter<V>, V extends TiVie
             + "@" + Integer.toHexString(this.hashCode());
 
     private final TiFragmentDelegate<P, V> mDelegate =
-            new TiFragmentDelegate<>(this, this, this, this);
+            new TiFragmentDelegate<>(this, this, this, this, PresenterSavior.INSTANCE);
 
     @NonNull
     @Override

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiFragment.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiFragment.java
@@ -17,6 +17,7 @@ package net.grandcentrix.thirtyinch;
 
 import net.grandcentrix.thirtyinch.internal.DelegatedTiFragment;
 import net.grandcentrix.thirtyinch.internal.InterceptableViewBinder;
+import net.grandcentrix.thirtyinch.internal.PresenterSavior;
 import net.grandcentrix.thirtyinch.internal.TiFragmentDelegate;
 import net.grandcentrix.thirtyinch.internal.TiLoggingTagProvider;
 import net.grandcentrix.thirtyinch.internal.TiPresenterProvider;
@@ -45,7 +46,7 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView> ext
             + "@" + Integer.toHexString(this.hashCode());
 
     private final TiFragmentDelegate<P, V> mDelegate =
-            new TiFragmentDelegate<>(this, this, this, this);
+            new TiFragmentDelegate<>(this, this, this, this, PresenterSavior.INSTANCE);
 
     private final UiThreadExecutor mUiThreadExecutor = new UiThreadExecutor();
 

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/PresenterSavior.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/PresenterSavior.java
@@ -38,7 +38,7 @@ public enum PresenterSavior implements TiPresenterSavior {
 
     private static final String TAG = PresenterSavior.class.getSimpleName();
 
-    private HashMap<String, TiPresenter> mPresenters = new HashMap<>();
+    private final HashMap<String, TiPresenter> mPresenters = new HashMap<>();
 
     @Override
     public void free(final String presenterId) {
@@ -47,14 +47,14 @@ public enum PresenterSavior implements TiPresenterSavior {
 
     @Override
     @Nullable
-    public TiPresenter recover(final String id) {
-        return mPresenters.get(id);
+    public TiPresenter recover(final String presenterId) {
+        return mPresenters.get(presenterId);
     }
 
     @Override
-    public String safe(@NonNull final TiPresenter presenter) {
+    public String save(@NonNull final TiPresenter presenter) {
         final String id = generateId(presenter);
-        TiLog.v(TAG, "safe presenter with id " + id + " " + presenter);
+        TiLog.v(TAG, "save presenter with id " + id + " " + presenter);
         mPresenters.put(id, presenter);
         return id;
     }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegate.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegate.java
@@ -54,7 +54,7 @@ public class TiActivityDelegate<P extends TiPresenter<V>, V extends TiView>
      */
     private volatile boolean mActivityStarted = false;
 
-    private TiLoggingTagProvider mLogTag;
+    private final TiLoggingTagProvider mLogTag;
 
     /**
      * The presenter to which this activity will be attached as view when in the right state.
@@ -75,15 +75,15 @@ public class TiActivityDelegate<P extends TiPresenter<V>, V extends TiView>
 
     private final PresenterViewBinder<V> mViewBinder;
 
-    private TiPresenterSavior mSavior;
+    private final TiPresenterSavior mSavior;
 
-    private TiViewProvider<V> mViewProvider;
+    private final TiViewProvider<V> mViewProvider;
 
     public TiActivityDelegate(final DelegatedTiActivity<P> activityProvider,
             final TiViewProvider<V> viewProvider,
             final TiPresenterProvider<P> presenterProvider,
             final TiLoggingTagProvider logTag,
-            TiPresenterSavior savior) {
+            final TiPresenterSavior savior) {
         mTiActivity = activityProvider;
         mViewProvider = viewProvider;
         mPresenterProvider = presenterProvider;

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegate.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegate.java
@@ -171,7 +171,7 @@ public class TiActivityDelegate<P extends TiPresenter<V>, V extends TiView>
                 // holding the presenter before, is now able to remove the reference to
                 // this presenter from the savior
                 mSavior.free(recoveredPresenterId);
-                mPresenterId = mSavior.safe(mPresenter);
+                mPresenterId = mSavior.save(mPresenter);
             }
         }
 
@@ -181,7 +181,7 @@ public class TiActivityDelegate<P extends TiPresenter<V>, V extends TiView>
             TiLog.v(mLogTag.getLoggingTag(), "created Presenter: " + mPresenter);
             final TiConfiguration config = mPresenter.getConfig();
             if (config.shouldRetainPresenter() && config.useStaticSaviorToRetain()) {
-                mPresenterId = mSavior.safe(mPresenter);
+                mPresenterId = mSavior.save(mPresenter);
             }
             mPresenter.create();
         }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiFragmentDelegate.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiFragmentDelegate.java
@@ -66,7 +66,7 @@ public class TiFragmentDelegate<P extends TiPresenter<V>, V extends TiView>
 
     private final PresenterViewBinder<V> mViewBinder;
 
-    private TiPresenterSavior mSavior;
+    private final TiPresenterSavior mSavior;
 
     private final TiViewProvider<V> mViewProvider;
 

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiFragmentDelegate.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiFragmentDelegate.java
@@ -138,7 +138,7 @@ public class TiFragmentDelegate<P extends TiPresenter<V>, V extends TiView>
                     // holding the presenter before, is now able to remove the reference to
                     // this presenter from the savior
                     mSavior.free(recoveredPresenterId);
-                    mPresenterId = mSavior.safe(mPresenter);
+                    mPresenterId = mSavior.save(mPresenter);
                 }
                 TiLog.v(mLogTag.getLoggingTag(), "recovered Presenter " + mPresenter);
             }
@@ -149,7 +149,7 @@ public class TiFragmentDelegate<P extends TiPresenter<V>, V extends TiView>
             TiLog.v(mLogTag.getLoggingTag(), "created Presenter: " + mPresenter);
             final TiConfiguration config = mPresenter.getConfig();
             if (config.shouldRetainPresenter() && config.useStaticSaviorToRetain()) {
-                mPresenterId = mSavior.safe(mPresenter);
+                mPresenterId = mSavior.save(mPresenter);
             }
             mPresenter.create();
         }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiPresenterSavior.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiPresenterSavior.java
@@ -15,25 +15,21 @@
 
 package net.grandcentrix.thirtyinch.internal;
 
+
 import net.grandcentrix.thirtyinch.TiPresenter;
 
-import java.util.HashMap;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 /**
- * helper to clear the savior in the test environment without exposing this to the public API
+ * store for presenters to survive when Activities get destroyed.
  */
-public class PresenterSaviorTestHelper {
+public interface TiPresenterSavior {
 
-    public static void clear() {
-        PresenterSavior.INSTANCE.clear();
-    }
+    void free(String presenterId);
 
-    public static int presenterCount() {
-        return presenters().entrySet().size();
-    }
+    @Nullable
+    TiPresenter recover(String id);
 
-    public static HashMap<String, TiPresenter> presenters() {
-        return PresenterSavior.INSTANCE.mPresenters;
-    }
-
+    String safe(@NonNull TiPresenter presenter);
 }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiPresenterSavior.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiPresenterSavior.java
@@ -22,14 +22,32 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 /**
- * store for presenters to survive when Activities get destroyed.
+ * Store for presenters to survive when their associated context gets destroyed (e.g. Activity or
+ * Fragment).
  */
 public interface TiPresenterSavior {
 
+    /**
+     * Frees a certain presenter from the store.
+     *
+     * @param presenterId the id of the presenter
+     */
     void free(String presenterId);
 
+    /**
+     * Gets a presenter from the store.
+     *
+     * @param presenterId the id of the presenter
+     * @return the presenter of {@code null} if no presenter could be found
+     */
     @Nullable
-    TiPresenter recover(String id);
+    TiPresenter recover(String presenterId);
 
-    String safe(@NonNull TiPresenter presenter);
+    /**
+     * Stores a presenter in the store.
+     *
+     * @param presenter the presenter that should be stored
+     * @return the id of the stored presenter
+     */
+    String save(@NonNull TiPresenter presenter);
 }

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/MockSavior.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/MockSavior.java
@@ -42,12 +42,12 @@ public class MockSavior implements TiPresenterSavior {
 
     @Nullable
     @Override
-    public TiPresenter recover(final String id) {
-        return mPresenters.get(id);
+    public TiPresenter recover(final String presenterId) {
+        return mPresenters.get(presenterId);
     }
 
     @Override
-    public String safe(@NonNull final TiPresenter presenter) {
+    public String save(@NonNull final TiPresenter presenter) {
         final String id = presenter.getClass().getSimpleName()
                 + ":" + presenter.hashCode()
                 + ":" + System.nanoTime();

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/MockSavior.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/MockSavior.java
@@ -15,8 +15,7 @@
 
 package net.grandcentrix.thirtyinch.internal;
 
-import net.grandcentrix.thirtyinch.TiActivity;
-import net.grandcentrix.thirtyinch.TiLog;
+
 import net.grandcentrix.thirtyinch.TiPresenter;
 
 import android.support.annotation.NonNull;
@@ -24,44 +23,35 @@ import android.support.annotation.Nullable;
 
 import java.util.HashMap;
 
-/**
- * Activities can be destroyed when the device runs out of memory. Sometimes it doesn't work to
- * save objects via {@code Activity#onRetainNonConfigurationInstance()} for example when the user
- * has enabled "Do not keep activities" in the developer options. This singleton holds strong
- * references to those presenters and returns them when needed.
- *
- * {@link TiActivity} is responsible to manage the references
- */
-public enum PresenterSavior implements TiPresenterSavior {
-
-    INSTANCE;
-
-    private static final String TAG = PresenterSavior.class.getSimpleName();
+public class MockSavior implements TiPresenterSavior {
 
     private HashMap<String, TiPresenter> mPresenters = new HashMap<>();
+
+    public void clear() {
+        mPresenters.clear();
+    }
 
     @Override
     public void free(final String presenterId) {
         mPresenters.remove(presenterId);
     }
 
-    @Override
+    public int presenterCount() {
+        return mPresenters.size();
+    }
+
     @Nullable
+    @Override
     public TiPresenter recover(final String id) {
         return mPresenters.get(id);
     }
 
     @Override
     public String safe(@NonNull final TiPresenter presenter) {
-        final String id = generateId(presenter);
-        TiLog.v(TAG, "safe presenter with id " + id + " " + presenter);
-        mPresenters.put(id, presenter);
-        return id;
-    }
-
-    private String generateId(@NonNull final TiPresenter presenter) {
-        return presenter.getClass().getSimpleName()
+        final String id = presenter.getClass().getSimpleName()
                 + ":" + presenter.hashCode()
                 + ":" + System.nanoTime();
+        mPresenters.put(id, presenter);
+        return id;
     }
 }

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegateBuilder.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegateBuilder.java
@@ -39,6 +39,8 @@ public class TiActivityDelegateBuilder {
 
     private TiPresenterProvider<TiPresenter<TiView>> mRetainedPresenterProvider;
 
+    private TiPresenterSavior mSavior = new MockSavior();
+
     public TiActivityDelegate<TiPresenter<TiView>, TiView> build() {
         TiPresenterProvider<TiPresenter<TiView>> presenterProvider = mPresenterProvider;
         if (presenterProvider == null) {
@@ -97,7 +99,7 @@ public class TiActivityDelegateBuilder {
             public String getLoggingTag() {
                 return "TestLogTag";
             }
-        });
+        }, mSavior);
     }
 
     public TiActivityDelegateBuilder setDontKeepActivitiesEnabled(final boolean enabled) {
@@ -129,6 +131,11 @@ public class TiActivityDelegateBuilder {
     public TiActivityDelegateBuilder setRetainedPresenterProvider(
             TiPresenterProvider<TiPresenter<TiView>> retainedPresenterProvider) {
         mRetainedPresenterProvider = retainedPresenterProvider;
+        return this;
+    }
+
+    public TiActivityDelegateBuilder setSavior(final TiPresenterSavior savior) {
+        mSavior = savior;
         return this;
     }
 }

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/TiActivityPresenterDestroyTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/TiActivityPresenterDestroyTest.java
@@ -20,6 +20,7 @@ import net.grandcentrix.thirtyinch.TiConfiguration;
 import net.grandcentrix.thirtyinch.TiPresenter;
 import net.grandcentrix.thirtyinch.TiView;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -57,6 +58,8 @@ public class TiActivityPresenterDestroyTest {
         }
     }
 
+    private MockSavior mSavior;
+
     @Test
     public void saviorFalse_dontKeepActivitiesFalse_configurationChange() throws Exception {
         final TestPresenter presenter = new TestPresenter(new TiConfiguration.Builder()
@@ -68,6 +71,7 @@ public class TiActivityPresenterDestroyTest {
                 .setIsFinishing(false)
                 .setIsChangingConfigurations(true)
                 .setDontKeepActivitiesEnabled(false)
+                .setSavior(mSavior)
                 .build();
 
         final Bundle savedState = mock(Bundle.class);
@@ -80,7 +84,7 @@ public class TiActivityPresenterDestroyTest {
         assertThat(putInMap.map.get(TiActivityDelegate.SAVED_STATE_PRESENTER_ID)).isNull();
 
         assertThat(presenter.isDestroyed()).isFalse();
-        assertThat(PresenterSaviorTestHelper.presenterCount()).isEqualTo(0);
+        assertThat(mSavior.presenterCount()).isEqualTo(0);
 
         delegate.onCreate_afterSuper(savedState);
     }
@@ -96,13 +100,14 @@ public class TiActivityPresenterDestroyTest {
                 .setIsFinishing(true)
                 .setIsChangingConfigurations(false)
                 .setDontKeepActivitiesEnabled(false)
+                .setSavior(mSavior)
                 .build();
 
         final Bundle savedState = mock(Bundle.class);
         doFullLifecycleAndDestroy(delegate, savedState);
 
         assertThat(presenter.isDestroyed()).isTrue();
-        assertThat(PresenterSaviorTestHelper.presenterCount()).isEqualTo(0);
+        assertThat(mSavior.presenterCount()).isEqualTo(0);
 
         try {
             // presenter is destroyed and cannot be recreated
@@ -125,12 +130,13 @@ public class TiActivityPresenterDestroyTest {
                 .setIsFinishing(false)
                 .setIsChangingConfigurations(false)
                 .setDontKeepActivitiesEnabled(false)
+                .setSavior(mSavior)
                 .build();
 
         final Bundle savedState = mock(Bundle.class);
         delegate.onCreate_afterSuper(null);
         // savior is disabled
-        assertThat(PresenterSaviorTestHelper.presenterCount()).isEqualTo(0);
+        assertThat(mSavior.presenterCount()).isEqualTo(0);
 
         assertThat(delegate.getPresenter().isInitialized()).isTrue();
 
@@ -145,7 +151,7 @@ public class TiActivityPresenterDestroyTest {
         delegate.onStart_afterSuper();
 
         assertThat(presenter.isDestroyed()).isFalse();
-        assertThat(PresenterSaviorTestHelper.presenterCount()).isEqualTo(0);
+        assertThat(mSavior.presenterCount()).isEqualTo(0);
     }
 
     @Test
@@ -159,6 +165,7 @@ public class TiActivityPresenterDestroyTest {
                 .setIsFinishing(false)
                 .setIsChangingConfigurations(true)
                 .setDontKeepActivitiesEnabled(true)
+                .setSavior(mSavior)
                 .build();
 
         final Bundle savedState = mock(Bundle.class);
@@ -171,7 +178,7 @@ public class TiActivityPresenterDestroyTest {
         assertThat(putInMap.map.get(TiActivityDelegate.SAVED_STATE_PRESENTER_ID)).isNull();
 
         assertThat(presenter.isDestroyed()).isFalse();
-        assertThat(PresenterSaviorTestHelper.presenterCount()).isEqualTo(0);
+        assertThat(mSavior.presenterCount()).isEqualTo(0);
 
         delegate.onCreate_afterSuper(null);
     }
@@ -187,13 +194,14 @@ public class TiActivityPresenterDestroyTest {
                 .setIsFinishing(true)
                 .setIsChangingConfigurations(false)
                 .setDontKeepActivitiesEnabled(true)
+                .setSavior(mSavior)
                 .build();
 
         final Bundle savedState = mock(Bundle.class);
         doFullLifecycleAndDestroy(delegate, savedState);
 
         assertThat(presenter.isDestroyed()).isTrue();
-        assertThat(PresenterSaviorTestHelper.presenterCount()).isEqualTo(0);
+        assertThat(mSavior.presenterCount()).isEqualTo(0);
 
         try {
             // presenter is destroyed and cannot be recreated
@@ -216,12 +224,13 @@ public class TiActivityPresenterDestroyTest {
                 .setIsFinishing(false)
                 .setIsChangingConfigurations(false)
                 .setDontKeepActivitiesEnabled(true)
+                .setSavior(mSavior)
                 .build();
 
         final Bundle savedState = mock(Bundle.class);
         delegate.onCreate_afterSuper(null);
         // savior is disabled
-        assertThat(PresenterSaviorTestHelper.presenterCount()).isEqualTo(0);
+        assertThat(mSavior.presenterCount()).isEqualTo(0);
 
         assertThat(delegate.getPresenter().isInitialized()).isTrue();
 
@@ -236,7 +245,7 @@ public class TiActivityPresenterDestroyTest {
         delegate.onStart_afterSuper();
 
         assertThat(presenter.isDestroyed()).isFalse();
-        assertThat(PresenterSaviorTestHelper.presenterCount()).isEqualTo(0);
+        assertThat(mSavior.presenterCount()).isEqualTo(0);
 
         delegate.onCreate_afterSuper(null);
     }
@@ -253,6 +262,7 @@ public class TiActivityPresenterDestroyTest {
                 .setIsFinishing(false)
                 .setIsChangingConfigurations(true)
                 .setDontKeepActivitiesEnabled(false)
+                .setSavior(mSavior)
                 .setRetainedPresenterProvider(new TiPresenterProvider<TiPresenter<TiView>>() {
                     @NonNull
                     @Override
@@ -273,7 +283,7 @@ public class TiActivityPresenterDestroyTest {
                 .contains("TestPresenter");
 
         assertThat(presenter.isDestroyed()).isFalse();
-        assertThat(PresenterSaviorTestHelper.presenterCount()).isEqualTo(1);
+        assertThat(mSavior.presenterCount()).isEqualTo(1);
 
         retainedPresenter[0] = presenter;
         delegate.onCreate_afterSuper(savedState);
@@ -290,13 +300,14 @@ public class TiActivityPresenterDestroyTest {
                 .setIsFinishing(true)
                 .setIsChangingConfigurations(false)
                 .setDontKeepActivitiesEnabled(false)
+                .setSavior(mSavior)
                 .build();
 
         final Bundle savedState = mock(Bundle.class);
         doFullLifecycleAndDestroy(delegate, savedState);
 
         assertThat(presenter.isDestroyed()).isTrue();
-        assertThat(PresenterSaviorTestHelper.presenterCount()).isEqualTo(0);
+        assertThat(mSavior.presenterCount()).isEqualTo(0);
 
         try {
             // presenter is destroyed and cannot be recreated
@@ -320,6 +331,7 @@ public class TiActivityPresenterDestroyTest {
                 .setIsFinishing(false)
                 .setIsChangingConfigurations(false)
                 .setDontKeepActivitiesEnabled(false)
+                .setSavior(mSavior)
                 .setRetainedPresenterProvider(new TiPresenterProvider<TiPresenter<TiView>>() {
                     @NonNull
                     @Override
@@ -331,7 +343,7 @@ public class TiActivityPresenterDestroyTest {
 
         final Bundle savedState = mock(Bundle.class);
         delegate.onCreate_afterSuper(null);
-        assertThat(PresenterSaviorTestHelper.presenterCount()).isEqualTo(1);
+        assertThat(mSavior.presenterCount()).isEqualTo(1);
 
         assertThat(delegate.getPresenter().isInitialized()).isTrue();
 
@@ -346,7 +358,7 @@ public class TiActivityPresenterDestroyTest {
         delegate.onStart_afterSuper();
 
         assertThat(presenter.isDestroyed()).isFalse();
-        assertThat(PresenterSaviorTestHelper.presenterCount()).isEqualTo(1);
+        assertThat(mSavior.presenterCount()).isEqualTo(1);
 
         retainedPresenter[0] = presenter;
         delegate.onCreate_afterSuper(savedState);
@@ -363,6 +375,7 @@ public class TiActivityPresenterDestroyTest {
                 .setIsFinishing(false)
                 .setIsChangingConfigurations(true)
                 .setDontKeepActivitiesEnabled(true)
+                .setSavior(mSavior)
                 .build();
 
         final Bundle savedState = mock(Bundle.class);
@@ -376,7 +389,7 @@ public class TiActivityPresenterDestroyTest {
                 .contains("TestPresenter");
 
         assertThat(presenter.isDestroyed()).isFalse();
-        assertThat(PresenterSaviorTestHelper.presenterCount()).isEqualTo(1);
+        assertThat(mSavior.presenterCount()).isEqualTo(1);
     }
 
     @Test
@@ -390,13 +403,14 @@ public class TiActivityPresenterDestroyTest {
                 .setIsFinishing(true)
                 .setIsChangingConfigurations(false)
                 .setDontKeepActivitiesEnabled(true)
+                .setSavior(mSavior)
                 .build();
 
         final Bundle savedState = mock(Bundle.class);
         doFullLifecycleAndDestroy(delegate, savedState);
 
         assertThat(presenter.isDestroyed()).isTrue();
-        assertThat(PresenterSaviorTestHelper.presenterCount()).isEqualTo(0);
+        assertThat(mSavior.presenterCount()).isEqualTo(0);
 
         try {
             // presenter is destroyed and cannot be recreated
@@ -419,18 +433,24 @@ public class TiActivityPresenterDestroyTest {
                 .setIsFinishing(false)
                 .setIsChangingConfigurations(false)
                 .setDontKeepActivitiesEnabled(true)
+                .setSavior(mSavior)
                 .build();
 
         final Bundle savedState = mock(Bundle.class);
         doFullLifecycleAndDestroy(delegate, savedState);
 
         assertThat(presenter.isDestroyed()).isFalse();
-        assertThat(PresenterSaviorTestHelper.presenterCount()).isEqualTo(1);
+        assertThat(mSavior.presenterCount()).isEqualTo(1);
     }
 
     @Before
     public void setUp() throws Exception {
-        PresenterSaviorTestHelper.clear();
+        mSavior = new MockSavior();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        mSavior.clear();
     }
 
     private void doFullLifecycleAndDestroy(final TiActivityDelegate<TiPresenter<TiView>, TiView> delegate,


### PR DESCRIPTION
Makes tests easier because the ActivityDelegate will now not work with a global `PresenterSavior` singleton.