### PR TITLE
Single support

### DIFF
--- a/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiObservableUtils.java
+++ b/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiObservableUtils.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2017 grandcentrix GmbH
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.grandcentrix.thirtyinch.rx;
+
+import net.grandcentrix.thirtyinch.TiPresenter;
+
+import rx.Observable;
+
+import static net.grandcentrix.thirtyinch.rx.RxTiUtils.isViewReady;
+
+public class RxTiObservableUtils {
+
+    /**
+     * Returns a transformer that will delay onNext, onError and onComplete emissions unless a view
+     * become available. getView() is guaranteed to be != null during all emissions. This
+     * transformer can only be used on application's main thread.
+     * <p/>
+     * If the transformer receives a next value while the previous value has not been delivered,
+     * the
+     * previous value will be dropped.
+     * <p/>
+     * The transformer will duplicate the latest onNext emission in case if a view has been
+     * reattached.
+     * <p/>
+     * This operator ignores onComplete emission and never sends one.
+     * <p/>
+     * Use this operator when you need to show updatable data that needs to be cached in memory.
+     *
+     * @param <T>       a type of onNext value.
+     * @param presenter the presenter waiting for the view
+     * @return the delaying operator.
+     */
+    public static <T> Observable.Transformer<T, T> deliverLatestCacheToView(
+            final TiPresenter presenter) {
+        return new Observable.Transformer<T, T>() {
+            @Override
+            public Observable<T> call(Observable<T> observable) {
+                return observable
+                        .lift(OperatorSemaphore.<T>semaphoreLatestCache(isViewReady(presenter)));
+            }
+        };
+    }
+
+    /**
+     * Returns a transformer that will delay onNext, onError and onComplete emissions unless a view
+     * become available. getView() is guaranteed to be != null during all emissions. This
+     * transformer can only be used on application's main thread.
+     * <p/>
+     * If this transformer receives a next value while the previous value has not been delivered,
+     * the previous value will be dropped.
+     * <p/>
+     * Use this operator when you need to show updatable data.
+     *
+     * @param <T>       a type of onNext value.
+     * @param presenter the presenter waiting for the view
+     * @return the delaying operator.
+     */
+    public static <T> Observable.Transformer<T, T> deliverLatestToView(
+            final TiPresenter presenter) {
+        return new Observable.Transformer<T, T>() {
+            @Override
+            public Observable<T> call(Observable<T> observable) {
+                return observable
+                        .lift(OperatorSemaphore.<T>semaphoreLatest(isViewReady(presenter)));
+            }
+        };
+    }
+
+    /**
+     * Returns a transformer that will delay onNext, onError and onComplete emissions unless a view
+     * become available. getView() is guaranteed to be != null during all emissions. This
+     * transformer can only be used on application's main thread. See the correct order:
+     * <pre>
+     * <code>
+     *
+     * .observeOn(AndroidSchedulers.mainThread())
+     * .compose(this.&lt;T&gt;deliverToView())
+     * </code>
+     * </pre>
+     * Use this operator if you need to deliver *all* emissions to a view, in example when you're
+     * sending items into adapter one by one.
+     *
+     * @param <T>       a type of onNext value.
+     * @param presenter the presenter waiting for the view
+     * @return the delaying operator.
+     */
+    public static <T> Observable.Transformer<T, T> deliverToView(final TiPresenter presenter) {
+        return new Observable.Transformer<T, T>() {
+            @Override
+            public Observable<T> call(Observable<T> observable) {
+                return observable.lift(OperatorSemaphore.<T>semaphore(isViewReady(presenter)));
+            }
+        };
+    }
+
+}

--- a/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterUtils.java
+++ b/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiPresenterUtils.java
@@ -15,136 +15,41 @@
 
 package net.grandcentrix.thirtyinch.rx;
 
-import net.grandcentrix.thirtyinch.Removable;
-import net.grandcentrix.thirtyinch.TiLifecycleObserver;
 import net.grandcentrix.thirtyinch.TiPresenter;
-import net.grandcentrix.thirtyinch.TiView;
 
 import rx.Observable;
-import rx.Subscriber;
-import rx.Subscription;
 
 public class RxTiPresenterUtils {
 
     /**
-     * Returns a transformer that will delay onNext, onError and onComplete emissions unless a view
-     * become available. getView() is guaranteed to be != null during all emissions. This
-     * transformer can only be used on application's main thread.
-     * <p/>
-     * If the transformer receives a next value while the previous value has not been delivered,
-     * the
-     * previous value will be dropped.
-     * <p/>
-     * The transformer will duplicate the latest onNext emission in case if a view has been
-     * reattached.
-     * <p/>
-     * This operator ignores onComplete emission and never sends one.
-     * <p/>
-     * Use this operator when you need to show updatable data that needs to be cached in memory.
-     *
-     * @param <T>       a type of onNext value.
-     * @param presenter the presenter waiting for the view
-     * @return the delaying operator.
+     * Deprecated. Please use {@link RxTiObservableUtils#deliverLatestCacheToView(TiPresenter)}.
      */
+    @Deprecated
     public static <T> Observable.Transformer<T, T> deliverLatestCacheToView(
             final TiPresenter presenter) {
-        return new Observable.Transformer<T, T>() {
-            @Override
-            public Observable<T> call(Observable<T> observable) {
-                return observable
-                        .lift(OperatorSemaphore.<T>semaphoreLatestCache(isViewReady(presenter)));
-            }
-        };
+        return RxTiObservableUtils.deliverLatestCacheToView(presenter);
     }
 
     /**
-     * Returns a transformer that will delay onNext, onError and onComplete emissions unless a view
-     * become available. getView() is guaranteed to be != null during all emissions. This
-     * transformer can only be used on application's main thread.
-     * <p/>
-     * If this transformer receives a next value while the previous value has not been delivered,
-     * the previous value will be dropped.
-     * <p/>
-     * Use this operator when you need to show updatable data.
-     *
-     * @param <T>       a type of onNext value.
-     * @param presenter the presenter waiting for the view
-     * @return the delaying operator.
+     * Deprecated. Please use {@link RxTiObservableUtils#deliverLatestToView(TiPresenter)}.
      */
+    @Deprecated
     public static <T> Observable.Transformer<T, T> deliverLatestToView(
             final TiPresenter presenter) {
-        return new Observable.Transformer<T, T>() {
-            @Override
-            public Observable<T> call(Observable<T> observable) {
-                return observable
-                        .lift(OperatorSemaphore.<T>semaphoreLatest(isViewReady(presenter)));
-            }
-        };
+        return RxTiObservableUtils.deliverLatestCacheToView(presenter);
     }
 
     /**
-     * Returns a transformer that will delay onNext, onError and onComplete emissions unless a view
-     * become available. getView() is guaranteed to be != null during all emissions. This
-     * transformer can only be used on application's main thread. See the correct order:
-     * <pre>
-     * <code>
-     *
-     * .observeOn(AndroidSchedulers.mainThread())
-     * .compose(this.&lt;T&gt;deliverToView())
-     * </code>
-     * </pre>
-     * Use this operator if you need to deliver *all* emissions to a view, in example when you're
-     * sending items into adapter one by one.
-     *
-     * @param <T>       a type of onNext value.
-     * @param presenter the presenter waiting for the view
-     * @return the delaying operator.
+     * @deprecated use {@link RxTiObservableUtils#deliverToView(TiPresenter)} instead
      */
     public static <T> Observable.Transformer<T, T> deliverToView(final TiPresenter presenter) {
-        return new Observable.Transformer<T, T>() {
-            @Override
-            public Observable<T> call(Observable<T> observable) {
-                return observable.lift(OperatorSemaphore.<T>semaphore(isViewReady(presenter)));
-            }
-        };
+        return RxTiObservableUtils.deliverToView(presenter);
     }
 
     /**
-     * Observable of the view state. The View is ready to receive calls after calling {@link
-     * TiPresenter#attachView(TiView)} and before calling {@link TiPresenter#detachView()}.
+     * @deprecated use {@link RxTiUtils#isViewReady(TiPresenter)} instead
      */
     public static Observable<Boolean> isViewReady(final TiPresenter presenter) {
-        return Observable.create(new Observable.OnSubscribe<Boolean>() {
-            @Override
-            public void call(final Subscriber<? super Boolean> subscriber) {
-                if (!subscriber.isUnsubscribed()) {
-                    subscriber.onNext(presenter.getState() == TiPresenter.State.VIEW_ATTACHED);
-                }
-
-                final Removable removable = presenter
-                        .addLifecycleObserver(new TiLifecycleObserver() {
-                            @Override
-                            public void onChange(final TiPresenter.State state,
-                                    final boolean hasLifecycleMethodBeenCalled) {
-                                if (!subscriber.isUnsubscribed()) {
-                                    subscriber.onNext(state == TiPresenter.State.VIEW_ATTACHED
-                                            && hasLifecycleMethodBeenCalled);
-                                }
-                            }
-                        });
-
-                subscriber.add(new Subscription() {
-                    @Override
-                    public boolean isUnsubscribed() {
-                        return removable.isRemoved();
-                    }
-
-                    @Override
-                    public void unsubscribe() {
-                        removable.remove();
-                    }
-                });
-            }
-        }).distinctUntilChanged();
+        return RxTiUtils.isViewReady(presenter);
     }
 }

--- a/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiSingleUtils.java
+++ b/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiSingleUtils.java
@@ -1,0 +1,36 @@
+package net.grandcentrix.thirtyinch.rx;
+
+import net.grandcentrix.thirtyinch.TiPresenter;
+
+import rx.Single;
+
+import static net.grandcentrix.thirtyinch.rx.RxTiUtils.isViewReady;
+
+public class RxTiSingleUtils {
+
+    /**
+     * Returns a transformer that will delay onSuccess and onError emissions unless a view
+     * become available. getView() is guaranteed to be != null during all emissions. This
+     * transformer can only be used on application's main thread. See the correct order:
+     * <pre>
+     * <code>
+     *
+     * .observeOn(AndroidSchedulers.mainThread())
+     * .compose(this.&lt;T&gt;deliverToView())
+     * </code>
+     * </pre>
+     *
+     * @param <T>       a type of onNext value.
+     * @param presenter the presenter waiting for the view
+     * @return the delaying operator.
+     */
+    public static <T> Single.Transformer<T, T> deliverToView(final TiPresenter presenter) {
+        return new Single.Transformer<T, T>() {
+            @Override
+            public Single<T> call(final Single<T> single) {
+                return single.lift(OperatorSemaphore.<T>semaphore(isViewReady(presenter)));
+            }
+        };
+    }
+
+}

--- a/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiUtils.java
+++ b/rx/src/main/java/net/grandcentrix/thirtyinch/rx/RxTiUtils.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2017 grandcentrix GmbH
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.grandcentrix.thirtyinch.rx;
+
+import net.grandcentrix.thirtyinch.Removable;
+import net.grandcentrix.thirtyinch.TiLifecycleObserver;
+import net.grandcentrix.thirtyinch.TiPresenter;
+import net.grandcentrix.thirtyinch.TiView;
+
+import rx.Observable;
+import rx.Subscriber;
+import rx.Subscription;
+
+public class RxTiUtils {
+
+    /**
+     * Observable of the view state. The View is ready to receive calls after calling {@link
+     * TiPresenter#attachView(TiView)} and before calling {@link TiPresenter#detachView()}.
+     */
+    public static Observable<Boolean> isViewReady(final TiPresenter presenter) {
+        return Observable.create(new Observable.OnSubscribe<Boolean>() {
+            @Override
+            public void call(final Subscriber<? super Boolean> subscriber) {
+                if (!subscriber.isUnsubscribed()) {
+                    subscriber.onNext(presenter.getState() == TiPresenter.State.VIEW_ATTACHED);
+                }
+
+                final Removable removable = presenter
+                        .addLifecycleObserver(new TiLifecycleObserver() {
+                            @Override
+                            public void onChange(final TiPresenter.State state,
+                                    final boolean hasLifecycleMethodBeenCalled) {
+                                if (!subscriber.isUnsubscribed()) {
+                                    subscriber.onNext(state == TiPresenter.State.VIEW_ATTACHED
+                                            && hasLifecycleMethodBeenCalled);
+                                }
+                            }
+                        });
+
+                subscriber.add(new Subscription() {
+                    @Override
+                    public boolean isUnsubscribed() {
+                        return removable.isRemoved();
+                    }
+
+                    @Override
+                    public void unsubscribe() {
+                        removable.remove();
+                    }
+                });
+            }
+        }).distinctUntilChanged();
+    }
+
+}

--- a/rx/src/test/java/net/grandcentrix/thirtyinch/rx/RxTiObservableUtilsTest.java
+++ b/rx/src/test/java/net/grandcentrix/thirtyinch/rx/RxTiObservableUtilsTest.java
@@ -32,7 +32,7 @@ import rx.observers.TestSubscriber;
 import static org.mockito.Mockito.mock;
 
 @RunWith(JUnit4.class)
-public class RxTiPresenterUtilsTest {
+public class RxTiObservableUtilsTest {
 
     private TiMockPresenter mPresenter;
 
@@ -56,7 +56,7 @@ public class RxTiPresenterUtilsTest {
 
         TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
         Observable.just(1, 2, 3)
-                .compose(RxTiPresenterUtils.<Integer>deliverLatestCacheToView(mPresenter))
+                .compose(RxTiObservableUtils.<Integer>deliverLatestCacheToView(mPresenter))
                 .subscribe(testSubscriber);
 
         mPresenter.attachView(mView);
@@ -73,7 +73,7 @@ public class RxTiPresenterUtilsTest {
 
         TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
         Observable.just(1, 2, 3)
-                .compose(RxTiPresenterUtils.<Integer>deliverLatestCacheToView(mPresenter))
+                .compose(RxTiObservableUtils.<Integer>deliverLatestCacheToView(mPresenter))
                 .subscribe(testSubscriber);
 
         testSubscriber.assertNotCompleted();
@@ -87,7 +87,7 @@ public class RxTiPresenterUtilsTest {
 
         TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
         Observable.just(1, 2, 3)
-                .compose(RxTiPresenterUtils.<Integer>deliverLatestToView(mPresenter))
+                .compose(RxTiObservableUtils.<Integer>deliverLatestToView(mPresenter))
                 .subscribe(testSubscriber);
 
         mPresenter.attachView(mView);
@@ -104,7 +104,7 @@ public class RxTiPresenterUtilsTest {
 
         TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
         Observable.just(1, 2, 3)
-                .compose(RxTiPresenterUtils.<Integer>deliverLatestToView(mPresenter))
+                .compose(RxTiObservableUtils.<Integer>deliverLatestToView(mPresenter))
                 .subscribe(testSubscriber);
 
         testSubscriber.assertCompleted();
@@ -119,7 +119,7 @@ public class RxTiPresenterUtilsTest {
 
         TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
         Observable.just(1, 2, 3)
-                .compose(RxTiPresenterUtils.<Integer>deliverToView(mPresenter))
+                .compose(RxTiObservableUtils.<Integer>deliverToView(mPresenter))
                 .subscribe(testSubscriber);
 
         testSubscriber.assertCompleted();
@@ -134,7 +134,7 @@ public class RxTiPresenterUtilsTest {
 
         TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
         Observable.just(1, 2, 3)
-                .compose(RxTiPresenterUtils.<Integer>deliverToView(mPresenter))
+                .compose(RxTiObservableUtils.<Integer>deliverToView(mPresenter))
                 .subscribe(testSubscriber);
 
         testSubscriber.assertCompleted();

--- a/rx/src/test/java/net/grandcentrix/thirtyinch/rx/RxTiSingleUtilsTest.java
+++ b/rx/src/test/java/net/grandcentrix/thirtyinch/rx/RxTiSingleUtilsTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2017 grandcentrix GmbH
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.grandcentrix.thirtyinch.rx;
+
+import net.grandcentrix.thirtyinch.TiView;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import rx.Single;
+import rx.observers.TestSubscriber;
+
+import static org.mockito.Mockito.mock;
+
+@RunWith(JUnit4.class)
+public class RxTiSingleUtilsTest {
+
+    private TiMockPresenter mMockPresenter;
+
+    private TiView mMockView;
+
+    private TestSubscriber<String> mTestSubscriber;
+
+    @Before
+    public void setUp() throws Exception {
+        mMockPresenter = new TiMockPresenter();
+        mMockPresenter.create();
+
+        mMockView = mock(TiView.class);
+
+        mTestSubscriber = new TestSubscriber<>();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        mMockPresenter = null;
+        mMockView = null;
+        mTestSubscriber = null;
+    }
+
+    @Test
+    public void testDeliverToView_AttachAfterSingleCreated_ShouldDeliver() throws Exception {
+        Single.just("PleaseDeliverMe")
+                .compose(RxTiSingleUtils.<String>deliverToView(mMockPresenter))
+                .subscribe(mTestSubscriber);
+
+        mMockPresenter.attachView(mMockView);
+
+        mTestSubscriber.assertNoErrors();
+        mTestSubscriber.assertValue("PleaseDeliverMe");
+        mTestSubscriber.assertCompleted();
+    }
+
+    @Test
+    public void testDeliverToView_WithAttachedView_ShouldDeliver() throws Exception {
+        mMockPresenter.attachView(mMockView);
+
+        Single.just("PleaseDeliverMe")
+                .compose(RxTiSingleUtils.<String>deliverToView(mMockPresenter))
+                .subscribe(mTestSubscriber);
+
+        mTestSubscriber.assertNoErrors();
+        mTestSubscriber.assertValue("PleaseDeliverMe");
+        mTestSubscriber.assertCompleted();
+    }
+
+    @Test
+    public void testDeliverToView_WithoutAttachedView_ShouldNotDeliver() throws Exception {
+        Single.just("PleaseDeliverMe")
+                .compose(RxTiSingleUtils.<String>deliverToView(mMockPresenter))
+                .subscribe(mTestSubscriber);
+
+        mTestSubscriber.assertNoErrors();
+        mTestSubscriber.assertNoValues();
+        mTestSubscriber.assertNotCompleted();
+    }
+}

--- a/rx2/src/main/java/net/grandcentrix/thirtyinch/rx2/RxTiPresenterUtils.java
+++ b/rx2/src/main/java/net/grandcentrix/thirtyinch/rx2/RxTiPresenterUtils.java
@@ -15,56 +15,17 @@
 
 package net.grandcentrix.thirtyinch.rx2;
 
-import net.grandcentrix.thirtyinch.Removable;
-import net.grandcentrix.thirtyinch.TiLifecycleObserver;
 import net.grandcentrix.thirtyinch.TiPresenter;
-import net.grandcentrix.thirtyinch.TiView;
 
 import io.reactivex.Observable;
-import io.reactivex.ObservableEmitter;
-import io.reactivex.ObservableOnSubscribe;
-import io.reactivex.disposables.Disposable;
 
 public class RxTiPresenterUtils {
 
     /**
-     * Observable of the view state. The View is ready to receive calls after calling {@link
-     * TiPresenter#attachView(TiView)} and before calling {@link TiPresenter#detachView()}.
+     * @deprecated use {@link RxTiUtils#isViewReady(TiPresenter)} instead
      */
     public static Observable<Boolean> isViewReady(final TiPresenter presenter) {
-        return Observable.create(new ObservableOnSubscribe<Boolean>() {
-            @Override
-            public void subscribe(final ObservableEmitter<Boolean> emitter)
-                    throws Exception {
-                if (!emitter.isDisposed()) {
-                    emitter.onNext(presenter.getState() == TiPresenter.State.VIEW_ATTACHED);
-                }
-
-                final Removable removable = presenter
-                        .addLifecycleObserver(new TiLifecycleObserver() {
-                            @Override
-                            public void onChange(final TiPresenter.State state,
-                                    final boolean hasLifecycleMethodBeenCalled) {
-                                if (!emitter.isDisposed()) {
-                                    emitter.onNext(state == TiPresenter.State.VIEW_ATTACHED
-                                            && hasLifecycleMethodBeenCalled);
-                                }
-                            }
-                        });
-
-                emitter.setDisposable(new Disposable() {
-                    @Override
-                    public void dispose() {
-                        removable.remove();
-                    }
-
-                    @Override
-                    public boolean isDisposed() {
-                        return removable.isRemoved();
-                    }
-                });
-            }
-        }).distinctUntilChanged();
+        return RxTiUtils.isViewReady(presenter);
     }
 
 }

--- a/rx2/src/main/java/net/grandcentrix/thirtyinch/rx2/RxTiUtils.java
+++ b/rx2/src/main/java/net/grandcentrix/thirtyinch/rx2/RxTiUtils.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2017 grandcentrix GmbH
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.grandcentrix.thirtyinch.rx2;
+
+import net.grandcentrix.thirtyinch.Removable;
+import net.grandcentrix.thirtyinch.TiLifecycleObserver;
+import net.grandcentrix.thirtyinch.TiPresenter;
+import net.grandcentrix.thirtyinch.TiView;
+
+import io.reactivex.Observable;
+import io.reactivex.ObservableEmitter;
+import io.reactivex.ObservableOnSubscribe;
+import io.reactivex.disposables.Disposable;
+
+public class RxTiUtils {
+
+    /**
+     * Observable of the view state. The View is ready to receive calls after calling {@link
+     * TiPresenter#attachView(TiView)} and before calling {@link TiPresenter#detachView()}.
+     */
+    public static Observable<Boolean> isViewReady(final TiPresenter presenter) {
+        return Observable.create(new ObservableOnSubscribe<Boolean>() {
+            @Override
+            public void subscribe(final ObservableEmitter<Boolean> emitter)
+                    throws Exception {
+                if (!emitter.isDisposed()) {
+                    emitter.onNext(presenter.getState() == TiPresenter.State.VIEW_ATTACHED);
+                }
+
+                final Removable removable = presenter
+                        .addLifecycleObserver(new TiLifecycleObserver() {
+                            @Override
+                            public void onChange(final TiPresenter.State state,
+                                    final boolean hasLifecycleMethodBeenCalled) {
+                                if (!emitter.isDisposed()) {
+                                    emitter.onNext(state == TiPresenter.State.VIEW_ATTACHED
+                                            && hasLifecycleMethodBeenCalled);
+                                }
+                            }
+                        });
+
+                emitter.setDisposable(new Disposable() {
+                    @Override
+                    public void dispose() {
+                        removable.remove();
+                    }
+
+                    @Override
+                    public boolean isDisposed() {
+                        return removable.isRemoved();
+                    }
+                });
+            }
+        }).distinctUntilChanged();
+    }
+
+}

--- a/rx2/src/test/java/net/grandcentrix/thirtyinch/rx2/RxTiUtilsTest.java
+++ b/rx2/src/test/java/net/grandcentrix/thirtyinch/rx2/RxTiUtilsTest.java
@@ -11,7 +11,7 @@ import io.reactivex.observers.TestObserver;
 
 import static org.mockito.Mockito.mock;
 
-public class RxTiPresenterUtilsTest {
+public class RxTiUtilsTest {
 
     private TiPresenter mPresenter;
 
@@ -34,7 +34,7 @@ public class RxTiPresenterUtilsTest {
     public void testIsViewReady_AttachView_ShouldCallValueFalseTrue() throws Exception {
         mPresenter.create();
 
-        final TestObserver<Boolean> test = RxTiPresenterUtils.isViewReady(mPresenter).test();
+        final TestObserver<Boolean> test = RxTiUtils.isViewReady(mPresenter).test();
 
         mPresenter.attachView(mView);
         test.assertValues(false, true);
@@ -44,7 +44,7 @@ public class RxTiPresenterUtilsTest {
     public void testIsViewReady_BeforeAttachView_ShouldCallValueFalse() throws Exception {
         mPresenter.create();
 
-        final TestObserver<Boolean> test = RxTiPresenterUtils.isViewReady(mPresenter).test();
+        final TestObserver<Boolean> test = RxTiUtils.isViewReady(mPresenter).test();
 
         test.assertValue(false);
     }
@@ -53,7 +53,7 @@ public class RxTiPresenterUtilsTest {
     public void testIsViewReady_DisposeBeforeAttachView_ShouldRemoveCallback() throws Exception {
         mPresenter.create();
 
-        final TestObserver<Boolean> test = RxTiPresenterUtils.isViewReady(mPresenter).test();
+        final TestObserver<Boolean> test = RxTiUtils.isViewReady(mPresenter).test();
 
         test.assertValue(false);
         test.dispose();

--- a/sample/src/main/java/net/grandcentrix/thirtyinch/sample/HelloWorldActivity.java
+++ b/sample/src/main/java/net/grandcentrix/thirtyinch/sample/HelloWorldActivity.java
@@ -25,6 +25,7 @@ import android.support.annotation.NonNull;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import rx.Observable;
 
@@ -56,6 +57,11 @@ public class HelloWorldActivity extends TiActivity<HelloWorldPresenter, HelloWor
     @Override
     public void showText(final String text) {
         mOutput.setText(text);
+    }
+
+    @Override
+    public void showToast(final String s) {
+        Toast.makeText(this, s, Toast.LENGTH_SHORT).show();
     }
 
     @Override

--- a/sample/src/main/java/net/grandcentrix/thirtyinch/sample/HelloWorldPresenter.java
+++ b/sample/src/main/java/net/grandcentrix/thirtyinch/sample/HelloWorldPresenter.java
@@ -16,6 +16,7 @@
 package net.grandcentrix.thirtyinch.sample;
 
 import net.grandcentrix.thirtyinch.TiPresenter;
+import net.grandcentrix.thirtyinch.rx.RxTiObservableUtils;
 import net.grandcentrix.thirtyinch.rx.RxTiPresenterSubscriptionHandler;
 import net.grandcentrix.thirtyinch.rx.RxTiPresenterUtils;
 
@@ -61,7 +62,7 @@ public class HelloWorldPresenter extends TiPresenter<HelloWorldView> {
         mText.onNext("Hello World!");
 
         rxSubscriptionHelper.manageSubscription(Observable.interval(0, 1, TimeUnit.SECONDS)
-                .compose(RxTiPresenterUtils.deliverLatestToView(this))
+                .compose(RxTiObservableUtils.deliverLatestToView(this))
                 .subscribe(uptime -> {
                     sendToView(view -> view.showPresenterUpTime(uptime));
                 }));

--- a/sample/src/main/java/net/grandcentrix/thirtyinch/sample/HelloWorldPresenter.java
+++ b/sample/src/main/java/net/grandcentrix/thirtyinch/sample/HelloWorldPresenter.java
@@ -18,14 +18,16 @@ package net.grandcentrix.thirtyinch.sample;
 import net.grandcentrix.thirtyinch.TiPresenter;
 import net.grandcentrix.thirtyinch.rx.RxTiObservableUtils;
 import net.grandcentrix.thirtyinch.rx.RxTiPresenterSubscriptionHandler;
-import net.grandcentrix.thirtyinch.rx.RxTiPresenterUtils;
+import net.grandcentrix.thirtyinch.rx.RxTiSingleUtils;
 
 import android.support.annotation.NonNull;
 
 import java.util.concurrent.TimeUnit;
 
 import rx.Observable;
+import rx.Single;
 import rx.Subscription;
+import rx.functions.Action1;
 import rx.functions.Func1;
 import rx.schedulers.Schedulers;
 import rx.subjects.BehaviorSubject;
@@ -78,6 +80,10 @@ public class HelloWorldPresenter extends TiPresenter<HelloWorldView> {
                 }, 1)
                 .doOnNext(integer -> mText.onNext("Count: " + mCounter))
                 .subscribe());
+
+        rxSubscriptionHelper.manageSubscription(Single.just("This is a Toast")
+                .compose(RxTiSingleUtils.deliverToView(this))
+                .subscribe(s -> getView().showToast(s)));
     }
 
     /**

--- a/sample/src/main/java/net/grandcentrix/thirtyinch/sample/HelloWorldView.java
+++ b/sample/src/main/java/net/grandcentrix/thirtyinch/sample/HelloWorldView.java
@@ -30,4 +30,6 @@ public interface HelloWorldView extends TiView {
     @CallOnMainThread
     @DistinctUntilChanged
     void showText(final String text);
+
+    void showToast(String s);
 }

--- a/sample/src/main/java/net/grandcentrix/thirtyinch/sample/SamplePresenter.java
+++ b/sample/src/main/java/net/grandcentrix/thirtyinch/sample/SamplePresenter.java
@@ -16,6 +16,7 @@
 package net.grandcentrix.thirtyinch.sample;
 
 import net.grandcentrix.thirtyinch.TiPresenter;
+import net.grandcentrix.thirtyinch.rx.RxTiObservableUtils;
 import net.grandcentrix.thirtyinch.rx.RxTiPresenterSubscriptionHandler;
 import net.grandcentrix.thirtyinch.rx.RxTiPresenterUtils;
 
@@ -34,7 +35,7 @@ public class SamplePresenter extends TiPresenter<SampleView> {
         super.onCreate();
 
         mSubscriptionHandler.manageSubscription(Observable.interval(0, 37, TimeUnit.MILLISECONDS)
-                .compose(RxTiPresenterUtils.deliverLatestToView(this))
+                .compose(RxTiObservableUtils.deliverLatestToView(this))
                 .subscribe(alive -> {
                     // deliverLatestToView makes getView() here @NonNull
                     getView().showText("I'm a fragment and alive for " + (alive * 37) + "ms");


### PR DESCRIPTION
This will fix #40 

Because in Java it is not possible to have the same Signature but a different return value I've splittet the RxTiPresenterUtils into three parts:
* `RxTiObservableUtils`
* `RxTiUtils`
* `RxTiSingleUtils`
`RxTiPresenterUtils` is deprecated now. 

I've removed the `Presenter` in the class name because you can use it in Activtiys as well..
It is really not recommended but not mandatory...

However. I've also changed these "pattern" in Rx2.
But at this time, because we have no `deliver*View` methods, only the `RxTiUtils` class exist.
We need in Rx2 also a `RxTiMaybeUtils` :)
But that will be done in the future...

I've also added a simple example in our sample.