### PR TITLE
Feature: restrict TiFragment api for subclasses

### DIFF
--- a/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiActivityPlugin.java
+++ b/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiActivityPlugin.java
@@ -38,6 +38,7 @@ import net.grandcentrix.thirtyinch.util.AnnotationUtil;
 import android.app.Activity;
 import android.content.res.Configuration;
 import android.os.Bundle;
+import android.support.annotation.CallSuper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
@@ -54,7 +55,7 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
         implements TiViewProvider<V>, DelegatedTiActivity<P>, TiLoggingTagProvider,
         InterceptableViewBinder<V>, PresenterAccessor<P, V> {
 
-    public static final String NCI_KEY_PRESENTER = "presenter";
+    private static final String NCI_KEY_PRESENTER = "presenter";
 
     private String TAG = this.getClass().getSimpleName()
             + "@" + Integer.toHexString(this.hashCode());
@@ -81,7 +82,7 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
 
     @NonNull
     @Override
-    public Removable addBindViewInterceptor(@NonNull final BindViewInterceptor interceptor) {
+    public final Removable addBindViewInterceptor(@NonNull final BindViewInterceptor interceptor) {
         return mDelegate.addBindViewInterceptor(interceptor);
     }
 
@@ -90,7 +91,7 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
      */
     @Nullable
     @Override
-    public V getInterceptedViewOf(@NonNull final BindViewInterceptor interceptor) {
+    public final V getInterceptedViewOf(@NonNull final BindViewInterceptor interceptor) {
         return mDelegate.getInterceptedViewOf(interceptor);
     }
 
@@ -100,7 +101,7 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
      */
     @NonNull
     @Override
-    public List<BindViewInterceptor> getInterceptors(
+    public final List<BindViewInterceptor> getInterceptors(
             @NonNull final Filter<BindViewInterceptor> predicate) {
         return mDelegate.getInterceptors(predicate);
     }
@@ -111,14 +112,14 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
     }
 
     @Override
-    public P getPresenter() {
+    public final P getPresenter() {
         return mDelegate.getPresenter();
     }
 
     @SuppressWarnings("unchecked")
     @Nullable
     @Override
-    public P getRetainedPresenter() {
+    public final P getRetainedPresenter() {
         final Object nci = getLastNonConfigurationInstance(NCI_KEY_PRESENTER);
         if (nci != null) {
             return (P) nci;
@@ -127,7 +128,7 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
     }
 
     @Override
-    public Executor getUiThreadExecutor() {
+    public final Executor getUiThreadExecutor() {
         return mUiThreadExecutor;
     }
 
@@ -136,7 +137,7 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
      * through all the interceptors (again).
      */
     @Override
-    public void invalidateView() {
+    public final void invalidateView() {
         mDelegate.invalidateView();
     }
 
@@ -146,33 +147,37 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
     }
 
     @Override
-    public boolean isActivityFinishing() {
+    public final boolean isActivityFinishing() {
         return getActivity().isFinishing();
     }
 
     @Override
-    public boolean isDontKeepActivitiesEnabled() {
+    public final boolean isDontKeepActivitiesEnabled() {
         return AndroidDeveloperOptions.isDontKeepActivitiesEnabled(getActivity());
     }
 
+    @CallSuper
     @Override
     public void onConfigurationChanged(final Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
         mDelegate.onConfigurationChanged_afterSuper(newConfig);
     }
 
+    @CallSuper
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         mDelegate.onCreate_afterSuper(savedInstanceState);
     }
 
+    @CallSuper
     @Override
     public void onDestroy() {
         super.onDestroy();
         mDelegate.onDestroy_afterSuper();
     }
 
+    @CallSuper
     @Override
     @Nullable
     public CompositeNonConfigurationInstance onRetainNonConfigurationInstance() {
@@ -188,18 +193,21 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
         return null;
     }
 
+    @CallSuper
     @Override
     public void onSaveInstanceState(final Bundle outState) {
         super.onSaveInstanceState(outState);
         mDelegate.onSaveInstanceState_afterSuper(outState);
     }
 
+    @CallSuper
     @Override
     public void onStart() {
         super.onStart();
         mDelegate.onStart_afterSuper();
     }
 
+    @CallSuper
     @Override
     public void onStop() {
         mDelegate.onStop_beforeSuper();

--- a/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiFragmentPlugin.java
+++ b/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiFragmentPlugin.java
@@ -36,6 +36,7 @@ import net.grandcentrix.thirtyinch.util.AndroidDeveloperOptions;
 import net.grandcentrix.thirtyinch.util.AnnotationUtil;
 
 import android.os.Bundle;
+import android.support.annotation.CallSuper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
@@ -82,7 +83,7 @@ public class TiFragmentPlugin<P extends TiPresenter<V>, V extends TiView> extend
 
     @NonNull
     @Override
-    public Removable addBindViewInterceptor(@NonNull final BindViewInterceptor interceptor) {
+    public final Removable addBindViewInterceptor(@NonNull final BindViewInterceptor interceptor) {
         return mDelegate.addBindViewInterceptor(interceptor);
     }
 
@@ -91,7 +92,7 @@ public class TiFragmentPlugin<P extends TiPresenter<V>, V extends TiView> extend
      */
     @Nullable
     @Override
-    public V getInterceptedViewOf(@NonNull final BindViewInterceptor interceptor) {
+    public final  V getInterceptedViewOf(@NonNull final BindViewInterceptor interceptor) {
         return mDelegate.getInterceptedViewOf(interceptor);
     }
 
@@ -101,7 +102,7 @@ public class TiFragmentPlugin<P extends TiPresenter<V>, V extends TiView> extend
      */
     @NonNull
     @Override
-    public List<BindViewInterceptor> getInterceptors(
+    public final List<BindViewInterceptor> getInterceptors(
             @NonNull final Filter<BindViewInterceptor> predicate) {
         return mDelegate.getInterceptors(predicate);
     }
@@ -112,12 +113,12 @@ public class TiFragmentPlugin<P extends TiPresenter<V>, V extends TiView> extend
     }
 
     @Override
-    public P getPresenter() {
+    public final P getPresenter() {
         return mDelegate.getPresenter();
     }
 
     @Override
-    public Executor getUiThreadExecutor() {
+    public final Executor getUiThreadExecutor() {
         return mUiThreadExecutor;
     }
 
@@ -126,41 +127,43 @@ public class TiFragmentPlugin<P extends TiPresenter<V>, V extends TiView> extend
      * through all the interceptors (again).
      */
     @Override
-    public void invalidateView() {
+    public final void invalidateView() {
         mDelegate.invalidateView();
     }
 
     @Override
-    public boolean isDontKeepActivitiesEnabled() {
+    public final boolean isDontKeepActivitiesEnabled() {
         return AndroidDeveloperOptions.isDontKeepActivitiesEnabled(getFragment().getActivity());
     }
 
     @Override
-    public boolean isFragmentAdded() {
+    public final boolean isFragmentAdded() {
         return getFragment().isAdded();
     }
 
     @Override
-    public boolean isFragmentDetached() {
+    public final boolean isFragmentDetached() {
         return getFragment().isDetached();
     }
 
     @Override
-    public boolean isHostingActivityChangingConfigurations() {
+    public final boolean isHostingActivityChangingConfigurations() {
         return getFragment().getActivity().isChangingConfigurations();
     }
 
     @Override
-    public boolean isHostingActivityFinishing() {
+    public final boolean isHostingActivityFinishing() {
         return getFragment().getActivity().isFinishing();
     }
 
+    @CallSuper
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         mDelegate.onCreate_afterSuper(savedInstanceState);
     }
 
+    @CallSuper
     @Nullable
     @Override
     public View onCreateView(final LayoutInflater inflater, @Nullable final ViewGroup container,
@@ -169,30 +172,35 @@ public class TiFragmentPlugin<P extends TiPresenter<V>, V extends TiView> extend
         return super.onCreateView(inflater, container, savedInstanceState);
     }
 
+    @CallSuper
     @Override
     public void onDestroy() {
         super.onDestroy();
         mDelegate.onDestroy_afterSuper();
     }
 
+    @CallSuper
     @Override
     public void onDestroyView() {
         mDelegate.onDestroyView_beforeSuper();
         super.onDestroyView();
     }
 
+    @CallSuper
     @Override
     public void onSaveInstanceState(final Bundle outState) {
         super.onSaveInstanceState(outState);
         mDelegate.onSaveInstanceState_afterSuper(outState);
     }
 
+    @CallSuper
     @Override
     public void onStart() {
         super.onStart();
         mDelegate.onStart_afterSuper();
     }
 
+    @CallSuper
     @Override
     public void onStop() {
         mDelegate.onStop_beforeSuper();
@@ -229,7 +237,7 @@ public class TiFragmentPlugin<P extends TiPresenter<V>, V extends TiView> extend
     }
 
     @Override
-    public void setFragmentRetainInstance(final boolean retain) {
+    public final void setFragmentRetainInstance(final boolean retain) {
         getFragment().setRetainInstance(retain);
     }
 

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
@@ -138,6 +138,7 @@ public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
     }
 
     @Nullable
+    @CallSuper
     @Override
     public Object onRetainCustomNonConfigurationInstance() {
         final P presenter = mDelegate.getPresenter();

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
@@ -30,6 +30,7 @@ import net.grandcentrix.thirtyinch.util.AnnotationUtil;
 
 import android.content.res.Configuration;
 import android.os.Bundle;
+import android.support.annotation.CallSuper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
@@ -56,19 +57,19 @@ public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
 
     @NonNull
     @Override
-    public Removable addBindViewInterceptor(@NonNull final BindViewInterceptor interceptor) {
+    public final Removable addBindViewInterceptor(@NonNull final BindViewInterceptor interceptor) {
         return mDelegate.addBindViewInterceptor(interceptor);
     }
 
     @Nullable
     @Override
-    public V getInterceptedViewOf(@NonNull final BindViewInterceptor interceptor) {
+    public final V getInterceptedViewOf(@NonNull final BindViewInterceptor interceptor) {
         return mDelegate.getInterceptedViewOf(interceptor);
     }
 
     @NonNull
     @Override
-    public List<BindViewInterceptor> getInterceptors(
+    public final List<BindViewInterceptor> getInterceptors(
             @NonNull final Filter<BindViewInterceptor> predicate) {
         return mDelegate.getInterceptors(predicate);
     }
@@ -82,14 +83,14 @@ public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
      * is {@code null} before {@link #onCreate(Bundle)}
      */
     @Override
-    public P getPresenter() {
+    public final P getPresenter() {
         return mDelegate.getPresenter();
     }
 
     @SuppressWarnings("unchecked")
     @Nullable
     @Override
-    public P getRetainedPresenter() {
+    public final P getRetainedPresenter() {
         // try recover presenter via lastNonConfigurationInstance
         // this works most of the time
         final Object nci = getLastCustomNonConfigurationInstance();
@@ -101,7 +102,7 @@ public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
     }
 
     @Override
-    public Executor getUiThreadExecutor() {
+    public final Executor getUiThreadExecutor() {
         return mUiThreadExecutor;
     }
 
@@ -110,25 +111,26 @@ public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
      * through all the interceptors (again).
      */
     @Override
-    public void invalidateView() {
+    public final void invalidateView() {
         mDelegate.invalidateView();
     }
 
     @Override
-    public boolean isActivityChangingConfigurations() {
+    public final boolean isActivityChangingConfigurations() {
         return isChangingConfigurations();
     }
 
     @Override
-    public boolean isActivityFinishing() {
+    public final boolean isActivityFinishing() {
         return isFinishing();
     }
 
     @Override
-    public boolean isDontKeepActivitiesEnabled() {
+    public final boolean isDontKeepActivitiesEnabled() {
         return AndroidDeveloperOptions.isDontKeepActivitiesEnabled(this);
     }
 
+    @CallSuper
     @Override
     public void onConfigurationChanged(final Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
@@ -186,30 +188,35 @@ public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
                 + "{presenter = " + presenter + "}";
     }
 
+    @CallSuper
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         mDelegate.onCreate_afterSuper(savedInstanceState);
     }
 
+    @CallSuper
     @Override
     protected void onDestroy() {
         super.onDestroy();
         mDelegate.onDestroy_afterSuper();
     }
 
+    @CallSuper
     @Override
     protected void onSaveInstanceState(final Bundle outState) {
         super.onSaveInstanceState(outState);
         mDelegate.onSaveInstanceState_afterSuper(outState);
     }
 
+    @CallSuper
     @Override
     protected void onStart() {
         super.onStart();
         mDelegate.onStart_afterSuper();
     }
 
+    @CallSuper
     @Override
     protected void onStop() {
         mDelegate.onStop_beforeSuper();

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiDialogFragment.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiDialogFragment.java
@@ -28,6 +28,7 @@ import net.grandcentrix.thirtyinch.util.AndroidDeveloperOptions;
 import net.grandcentrix.thirtyinch.util.AnnotationUtil;
 
 import android.os.Bundle;
+import android.support.annotation.CallSuper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatDialogFragment;
@@ -52,19 +53,19 @@ public abstract class TiDialogFragment<P extends TiPresenter<V>, V extends TiVie
 
     @NonNull
     @Override
-    public Removable addBindViewInterceptor(@NonNull final BindViewInterceptor interceptor) {
+    public final Removable addBindViewInterceptor(@NonNull final BindViewInterceptor interceptor) {
         return mDelegate.addBindViewInterceptor(interceptor);
     }
 
     @Nullable
     @Override
-    public V getInterceptedViewOf(@NonNull final BindViewInterceptor interceptor) {
+    public final V getInterceptedViewOf(@NonNull final BindViewInterceptor interceptor) {
         return mDelegate.getInterceptedViewOf(interceptor);
     }
 
     @NonNull
     @Override
-    public List<BindViewInterceptor> getInterceptors(
+    public final List<BindViewInterceptor> getInterceptors(
             @NonNull final Filter<BindViewInterceptor> predicate) {
         return mDelegate.getInterceptors(predicate);
     }
@@ -75,12 +76,12 @@ public abstract class TiDialogFragment<P extends TiPresenter<V>, V extends TiVie
     }
 
     @Override
-    public P getPresenter() {
+    public final P getPresenter() {
         return mDelegate.getPresenter();
     }
 
     @Override
-    public Executor getUiThreadExecutor() {
+    public final Executor getUiThreadExecutor() {
         return new UiThreadExecutor();
     }
 
@@ -89,41 +90,43 @@ public abstract class TiDialogFragment<P extends TiPresenter<V>, V extends TiVie
      * through all the interceptors (again).
      */
     @Override
-    public void invalidateView() {
+    public final void invalidateView() {
         mDelegate.invalidateView();
     }
 
     @Override
-    public boolean isDontKeepActivitiesEnabled() {
+    public final boolean isDontKeepActivitiesEnabled() {
         return AndroidDeveloperOptions.isDontKeepActivitiesEnabled(getActivity());
     }
 
     @Override
-    public boolean isFragmentAdded() {
+    public final boolean isFragmentAdded() {
         return isAdded();
     }
 
     @Override
-    public boolean isFragmentDetached() {
+    public final boolean isFragmentDetached() {
         return isDetached();
     }
 
     @Override
-    public boolean isHostingActivityChangingConfigurations() {
+    public final boolean isHostingActivityChangingConfigurations() {
         return getActivity().isChangingConfigurations();
     }
 
     @Override
-    public boolean isHostingActivityFinishing() {
+    public final boolean isHostingActivityFinishing() {
         return getActivity().isFinishing();
     }
 
+    @CallSuper
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         mDelegate.onCreate_afterSuper(savedInstanceState);
     }
 
+    @CallSuper
     @Nullable
     @Override
     public View onCreateView(final LayoutInflater inflater, @Nullable final ViewGroup container,
@@ -132,30 +135,35 @@ public abstract class TiDialogFragment<P extends TiPresenter<V>, V extends TiVie
         return super.onCreateView(inflater, container, savedInstanceState);
     }
 
+    @CallSuper
     @Override
     public void onDestroy() {
         super.onDestroy();
         mDelegate.onDestroy_afterSuper();
     }
 
+    @CallSuper
     @Override
     public void onDestroyView() {
         mDelegate.onDestroyView_beforeSuper();
         super.onDestroyView();
     }
 
+    @CallSuper
     @Override
     public void onSaveInstanceState(final Bundle outState) {
         super.onSaveInstanceState(outState);
         mDelegate.onSaveInstanceState_afterSuper(outState);
     }
 
+    @CallSuper
     @Override
     public void onStart() {
         super.onStart();
         mDelegate.onStart_afterSuper();
     }
 
+    @CallSuper
     @Override
     public void onStop() {
         mDelegate.onStop_beforeSuper();
@@ -192,7 +200,7 @@ public abstract class TiDialogFragment<P extends TiPresenter<V>, V extends TiVie
     }
 
     @Override
-    public void setFragmentRetainInstance(final boolean retain) {
+    public final void setFragmentRetainInstance(final boolean retain) {
         setRetainInstance(retain);
     }
 

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiFragment.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiFragment.java
@@ -28,6 +28,7 @@ import net.grandcentrix.thirtyinch.util.AndroidDeveloperOptions;
 import net.grandcentrix.thirtyinch.util.AnnotationUtil;
 
 import android.os.Bundle;
+import android.support.annotation.CallSuper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
@@ -122,12 +123,14 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView> ext
         return getActivity().isFinishing();
     }
 
+    @CallSuper
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         mDelegate.onCreate_afterSuper(savedInstanceState);
     }
 
+    @CallSuper
     @Nullable
     @Override
     public View onCreateView(final LayoutInflater inflater, @Nullable final ViewGroup container,
@@ -136,30 +139,35 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView> ext
         return super.onCreateView(inflater, container, savedInstanceState);
     }
 
+    @CallSuper
     @Override
     public void onDestroy() {
         super.onDestroy();
         mDelegate.onDestroy_afterSuper();
     }
 
+    @CallSuper
     @Override
     public void onDestroyView() {
         mDelegate.onDestroyView_beforeSuper();
         super.onDestroyView();
     }
 
+    @CallSuper
     @Override
     public void onSaveInstanceState(final Bundle outState) {
         super.onSaveInstanceState(outState);
         mDelegate.onSaveInstanceState_afterSuper(outState);
     }
 
+    @CallSuper
     @Override
     public void onStart() {
         super.onStart();
         mDelegate.onStart_afterSuper();
     }
 
+    @CallSuper
     @Override
     public void onStop() {
         mDelegate.onStop_beforeSuper();

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiFragment.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiFragment.java
@@ -53,19 +53,19 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView> ext
 
     @NonNull
     @Override
-    public Removable addBindViewInterceptor(@NonNull final BindViewInterceptor interceptor) {
+    public final Removable addBindViewInterceptor(@NonNull final BindViewInterceptor interceptor) {
         return mDelegate.addBindViewInterceptor(interceptor);
     }
 
     @Nullable
     @Override
-    public V getInterceptedViewOf(@NonNull final BindViewInterceptor interceptor) {
+    public final V getInterceptedViewOf(@NonNull final BindViewInterceptor interceptor) {
         return mDelegate.getInterceptedViewOf(interceptor);
     }
 
     @NonNull
     @Override
-    public List<BindViewInterceptor> getInterceptors(
+    public final List<BindViewInterceptor> getInterceptors(
             @NonNull final Filter<BindViewInterceptor> predicate) {
         return mDelegate.getInterceptors(predicate);
     }
@@ -79,12 +79,12 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView> ext
      * is {@code null} before {@link #onCreate(Bundle)}
      */
     @Override
-    public P getPresenter() {
+    public final P getPresenter() {
         return mDelegate.getPresenter();
     }
 
     @Override
-    public Executor getUiThreadExecutor() {
+    public final Executor getUiThreadExecutor() {
         return mUiThreadExecutor;
     }
 
@@ -93,32 +93,32 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView> ext
      * through all the interceptors (again).
      */
     @Override
-    public void invalidateView() {
+    public final void invalidateView() {
         mDelegate.invalidateView();
     }
 
     @Override
-    public boolean isDontKeepActivitiesEnabled() {
+    public final boolean isDontKeepActivitiesEnabled() {
         return AndroidDeveloperOptions.isDontKeepActivitiesEnabled(getActivity());
     }
 
     @Override
-    public boolean isFragmentAdded() {
+    public final boolean isFragmentAdded() {
         return isAdded();
     }
 
     @Override
-    public boolean isFragmentDetached() {
+    public final boolean isFragmentDetached() {
         return isDetached();
     }
 
     @Override
-    public boolean isHostingActivityChangingConfigurations() {
+    public final boolean isHostingActivityChangingConfigurations() {
         return getActivity().isChangingConfigurations();
     }
 
     @Override
-    public boolean isHostingActivityFinishing() {
+    public final boolean isHostingActivityFinishing() {
         return getActivity().isFinishing();
     }
 
@@ -196,7 +196,7 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView> ext
     }
 
     @Override
-    public void setFragmentRetainInstance(final boolean retain) {
+    public final void setFragmentRetainInstance(final boolean retain) {
         setRetainInstance(retain);
     }
 


### PR DESCRIPTION
This pull request restricts the `TiFragment` api by declaring some implemented methods from the `DelegatedTiFragment`-Interface as `final` so they cannot be overridden by subclasses.
It also adds the `@CallSuper`-Annotation to all important lifecycle methods that requires calling the super implementation because `TiFragment` uses this lifecycle methods to manage the `TiFragmentDelegate` instance.

This should help to prevent issues which are caused by extending `TiFragment` and not call its respective super implementations (see #29 for example).

@passsy suggested to use the `FragmentManager.FragmentLifecycleCallbacks` (https://developer.android.com/reference/android/support/v4/app/FragmentManager.FragmentLifecycleCallbacks.html) to enforce the calls on the managed `TiFragmentDelegate` instance but since we are trying to hit the 0.8.0 release i think this would be a rather drastic improvement.