### PR TITLE
Minimize correctly with Proguard

### DIFF
--- a/rx/build.gradle
+++ b/rx/build.gradle
@@ -38,6 +38,7 @@ android {
 dependencies {
     compile project(':thirtyinch')
     compile 'io.reactivex:rxjava:1.2.3'
+    compile 'com.artemzin.rxjava:proguard-rules:1.2.3.0'
     provided "com.android.support:support-annotations:$supportLibraryVersion"
 
     testCompile "junit:junit:$junitVersion"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -16,6 +16,13 @@ android {
         versionName "1.0"
     }
     buildTypes {
+        debug {
+            // for testing proguard
+            //
+            // minifyEnabled true
+            // useProguard true
+            // proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -17,15 +17,18 @@ android {
     }
     buildTypes {
         debug {
+            // only use the build in shrinker for debug builds, don't obfuscate
             // remove unused classes and to make sure the proguard config is correct
+            // http://tools.android.com/tech-docs/new-build-system/built-in-shrinker
             // https://developer.android.com/studio/build/shrink-code.html#shrink-code
             minifyEnabled true
-            // don't enable proguard, it doesn't work with instant run
+            // using the build in shrinker only works with proguard disabled
             // https://developer.android.com/studio/build/shrink-code.html#gradle-shrinker
             useProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         release {
+            // use real proguard for release builds, not the build in shrinker which doesn't support obfuscation
             useProguard true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -17,14 +17,16 @@ android {
     }
     buildTypes {
         debug {
-            // for testing proguard
-            //
-            // minifyEnabled true
-            // useProguard true
-            // proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            // remove unused classes and to make sure the proguard config is correct
+            // https://developer.android.com/studio/build/shrink-code.html#shrink-code
+            minifyEnabled true
+            // don't enable proguard, it doesn't work with instant run
+            // https://developer.android.com/studio/build/shrink-code.html#gradle-shrinker
+            useProguard false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         release {
-            minifyEnabled false
+            useProguard true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }

--- a/thirtyinch/build.gradle
+++ b/thirtyinch/build.gradle
@@ -21,6 +21,7 @@ android {
         versionCode VERSION_CODE
         versionName VERSION_NAME
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles 'proguard-rules.txt'
     }
     buildTypes {
         release {

--- a/thirtyinch/proguard-rules.txt
+++ b/thirtyinch/proguard-rules.txt
@@ -1,0 +1,2 @@
+# ThirtyInch
+-keep public class * implements net.grandcentrix.thirtyinch.distinctuntilchanged.DistinctComparator


### PR DESCRIPTION
## Description

Bundles the proguard rules required for `Ti` within the `aar` artifacts. ThirtyInch now support Proguard without additional adjustments 

## How to test
- Enable proguard in app (sample app here is fine) and build. Everything works
- remove `rxjava:proguard-rules` dependency, build will fail
- remove keep rule for `DistinctComparator` will crash at runtime (app startup)