### PR TITLE
Add getViewOrThrow() for convenience

### DIFF
--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
@@ -316,19 +316,18 @@ public abstract class TiPresenter<V extends TiView> {
 
     /**
      * Gets the currently attached view or throws an {@link IllegalStateException} if the view
-     * is not attached. If you want to invoke methods on your view even when the view isn't
-     * currently attached or your can't be sure that the view is currently attached you should
-     * better use {@link #sendToView(ViewAction)} where the action will be executed when the view is
-     * attached.
+     * is not attached. Use this method if you are sure that a view is currently attached to the
+     * presenter. If you're not sure you should better use {@link #sendToView(ViewAction)} where the
+     * action will be executed when the view is attached.
      *
      * @return the currently attached view of this presenter
      */
     @NonNull
     public V getViewOrThrow() {
-
         final V view = getView();
         if (view == null) {
-            throw new IllegalStateException("view is not attached");
+            throw new IllegalStateException(
+                    "The view is currently not attached. Use 'sendToView(ViewAction)' instead.");
         }
 
         return view;

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
@@ -300,7 +300,7 @@ public abstract class TiPresenter<V extends TiView> {
     }
 
     /**
-     * Returns the currently attached view. The view is attached between the lifecycle callbacks
+     * Gets the currently attached view. The view is attached between the lifecycle callbacks
      * {@link #onAttachView(TiView)} and {@link #onSleep()}.
      * <p>
      * If you don't care about the view being attached or detached you should either rethink your
@@ -312,6 +312,26 @@ public abstract class TiPresenter<V extends TiView> {
     @Nullable
     public V getView() {
         return mView;
+    }
+
+    /**
+     * Gets the currently attached view or throws an {@link IllegalStateException} if the view
+     * is not attached. If you want to invoke methods on your view even when the view isn't
+     * currently attached or your can't be sure that the view is currently attached you should
+     * better use {@link #sendToView(ViewAction)} where the action will be executed when the view is
+     * attached.
+     *
+     * @return the currently attached view of this presenter
+     */
+    @NonNull
+    public V getViewOrThrow() {
+
+        final V view = getView();
+        if (view == null) {
+            throw new IllegalStateException("view is not attached");
+        }
+
+        return view;
     }
 
     public boolean isDestroyed() {

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/TiPresenterTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/TiPresenterTest.java
@@ -29,8 +29,10 @@ import java.util.concurrent.TimeUnit;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotSame;
+import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -273,7 +275,36 @@ public class TiPresenterTest {
     }
 
     @Test
-    public void testGetView() throws Exception {
+    public void testGetViewOrThrow() {
+        mPresenter.create();
+        mPresenter.attachView(mView);
+        mPresenter.detachView();
+
+        try {
+            mPresenter.getViewOrThrow();
+            failBecauseExceptionWasNotThrown(IllegalStateException.class);
+        } catch (IllegalStateException e) {
+            assertThat(e.getMessage(), equalTo("view is not attached"));
+        }
+    }
+
+    @Test
+    public void testGetViewOrThrowReturnsView() {
+        mPresenter.create();
+        mPresenter.attachView(mView);
+        assertThat(mPresenter.getViewOrThrow(), equalTo(mView));
+    }
+
+    @Test
+    public void testGetViewReturnsNull() {
+        mPresenter.create();
+        mPresenter.attachView(mView);
+        mPresenter.detachView();
+        assertNull(mPresenter.getView());
+    }
+
+    @Test
+    public void testGetViewReturnsView() {
         mPresenter.create();
         mPresenter.attachView(mView);
         assertThat(mPresenter.getView(), equalTo(mView));

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/TiPresenterTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/TiPresenterTest.java
@@ -284,7 +284,8 @@ public class TiPresenterTest {
             mPresenter.getViewOrThrow();
             failBecauseExceptionWasNotThrown(IllegalStateException.class);
         } catch (IllegalStateException e) {
-            assertThat(e.getMessage(), equalTo("view is not attached"));
+            assertThat(e.getMessage(),
+                    equalTo("The view is currently not attached. Use 'sendToView(ViewAction)' instead."));
         }
     }
 


### PR DESCRIPTION
As you may have read @passsy [blog post](https://android.jlelse.eu/dont-put-view-null-checks-in-your-presenters-4b6026c67423) about how we should handle detached views in your presenter implementations, I've added a `getViewOrThrow()` method for convenience to the `TiPresenter` which either returns the attached view or throws an `IllegalStateException`.