### PR TITLE
Feature/presenter host refactoring

### DIFF
--- a/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiActivityPlugin.java
+++ b/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiActivityPlugin.java
@@ -140,7 +140,7 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
     }
 
     @Override
-    public Object getHostingContainer() {
+    public final Object getHostingContainer() {
         return getActivity();
     }
 

--- a/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiActivityPlugin.java
+++ b/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiActivityPlugin.java
@@ -140,7 +140,7 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
     }
 
     @Override
-    public Activity getHostingActivity() {
+    public Object getHostingContainer() {
         return getActivity();
     }
 

--- a/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiFragmentPlugin.java
+++ b/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiFragmentPlugin.java
@@ -34,7 +34,6 @@ import net.grandcentrix.thirtyinch.internal.TiViewProvider;
 import net.grandcentrix.thirtyinch.internal.UiThreadExecutor;
 import net.grandcentrix.thirtyinch.util.AnnotationUtil;
 
-import android.app.Activity;
 import android.os.Bundle;
 import android.support.annotation.CallSuper;
 import android.support.annotation.NonNull;
@@ -89,8 +88,8 @@ public class TiFragmentPlugin<P extends TiPresenter<V>, V extends TiView> extend
     }
 
     @Override
-    public Activity getHostingActivity() {
-        return getFragment().getActivity();
+    public Object getHostingContainer() {
+        return getFragment().getHost();
     }
 
     /**
@@ -148,23 +147,13 @@ public class TiFragmentPlugin<P extends TiPresenter<V>, V extends TiView> extend
     }
 
     @Override
-    public boolean isFragmentRemoving() {
-        return getFragment().isRemoving();
-    }
-
-    @Override
-    public final boolean isHostingActivityChangingConfigurations() {
-        return getFragment().getActivity().isChangingConfigurations();
-    }
-
-    @Override
-    public final boolean isHostingActivityFinishing() {
-        return getFragment().getActivity().isFinishing();
-    }
-
-    @Override
     public boolean isFragmentInBackstack() {
         return BackstackReader.isInBackStack(getFragment());
+    }
+
+    @Override
+    public boolean isFragmentRemoving() {
+        return getFragment().isRemoving();
     }
 
     @CallSuper

--- a/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiFragmentPlugin.java
+++ b/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiFragmentPlugin.java
@@ -88,7 +88,7 @@ public class TiFragmentPlugin<P extends TiPresenter<V>, V extends TiView> extend
     }
 
     @Override
-    public Object getHostingContainer() {
+    public final Object getHostingContainer() {
         return getFragment().getHost();
     }
 

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
@@ -26,7 +26,6 @@ import net.grandcentrix.thirtyinch.internal.TiViewProvider;
 import net.grandcentrix.thirtyinch.internal.UiThreadExecutor;
 import net.grandcentrix.thirtyinch.util.AnnotationUtil;
 
-import android.app.Activity;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.support.annotation.CallSuper;
@@ -107,7 +106,7 @@ public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
     }
 
     @Override
-    public Activity getHostingActivity() {
+    public Object getHostingContainer() {
         return this;
     }
 

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
@@ -106,7 +106,7 @@ public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
     }
 
     @Override
-    public Object getHostingContainer() {
+    public final Object getHostingContainer() {
         return this;
     }
 

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiDialogFragment.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiDialogFragment.java
@@ -56,6 +56,11 @@ public abstract class TiDialogFragment<P extends TiPresenter<V>, V extends TiVie
         return mDelegate.addBindViewInterceptor(interceptor);
     }
 
+    @Override
+    public Object getHostingContainer() {
+        return getHost();
+    }
+
     @Nullable
     @Override
     public final V getInterceptedViewOf(@NonNull final BindViewInterceptor interceptor) {
@@ -101,16 +106,6 @@ public abstract class TiDialogFragment<P extends TiPresenter<V>, V extends TiVie
     @Override
     public final boolean isFragmentDetached() {
         return isDetached();
-    }
-
-    @Override
-    public final boolean isHostingActivityChangingConfigurations() {
-        return getActivity().isChangingConfigurations();
-    }
-
-    @Override
-    public final boolean isHostingActivityFinishing() {
-        return getActivity().isFinishing();
     }
 
     @CallSuper

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiDialogFragment.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiDialogFragment.java
@@ -58,7 +58,7 @@ public abstract class TiDialogFragment<P extends TiPresenter<V>, V extends TiVie
     }
 
     @Override
-    public Object getHostingContainer() {
+    public final Object getHostingContainer() {
         return getHost();
     }
 
@@ -110,12 +110,12 @@ public abstract class TiDialogFragment<P extends TiPresenter<V>, V extends TiVie
     }
 
     @Override
-    public boolean isFragmentInBackstack() {
+    public final boolean isFragmentInBackstack() {
         return BackstackReader.isInBackStack(this);
     }
 
     @Override
-    public boolean isFragmentRemoving() {
+    public final boolean isFragmentRemoving() {
         return isRemoving();
     }
 

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiDialogFragment.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiDialogFragment.java
@@ -30,6 +30,7 @@ import android.os.Bundle;
 import android.support.annotation.CallSuper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.app.BackstackReader;
 import android.support.v7.app.AppCompatDialogFragment;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -106,6 +107,16 @@ public abstract class TiDialogFragment<P extends TiPresenter<V>, V extends TiVie
     @Override
     public final boolean isFragmentDetached() {
         return isDetached();
+    }
+
+    @Override
+    public boolean isFragmentInBackstack() {
+        return BackstackReader.isInBackStack(this);
+    }
+
+    @Override
+    public boolean isFragmentRemoving() {
+        return isRemoving();
     }
 
     @CallSuper

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiFragment.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiFragment.java
@@ -127,7 +127,7 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView> ext
     }
 
     @Override
-    public Object getHostingContainer() {
+    public final Object getHostingContainer() {
         return getHost();
     }
 

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiFragment.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiFragment.java
@@ -26,7 +26,6 @@ import net.grandcentrix.thirtyinch.internal.TiViewProvider;
 import net.grandcentrix.thirtyinch.internal.UiThreadExecutor;
 import net.grandcentrix.thirtyinch.util.AnnotationUtil;
 
-import android.app.Activity;
 import android.os.Bundle;
 import android.support.annotation.CallSuper;
 import android.support.annotation.NonNull;
@@ -128,8 +127,8 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView> ext
     }
 
     @Override
-    public Activity getHostingActivity() {
-        return getActivity();
+    public Object getHostingContainer() {
+        return getHost();
     }
 
     @Nullable
@@ -183,23 +182,13 @@ public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView> ext
     }
 
     @Override
-    public boolean isFragmentRemoving() {
-        return isRemoving();
-    }
-
-    @Override
-    public final boolean isHostingActivityChangingConfigurations() {
-        return getActivity().isChangingConfigurations();
-    }
-
-    @Override
-    public final boolean isHostingActivityFinishing() {
-        return getActivity().isFinishing();
-    }
-
-    @Override
     public boolean isFragmentInBackstack() {
         return BackstackReader.isInBackStack(this);
+    }
+
+    @Override
+    public boolean isFragmentRemoving() {
+        return isRemoving();
     }
 
     @CallSuper

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
@@ -231,6 +231,11 @@ public abstract class TiPresenter<V extends TiView> {
      * @see #onDestroy()
      */
     public final void destroy() {
+        if (isViewAttached()) {
+            throw new IllegalStateException(
+                    "view is attached, can't destroy the presenter. First call detachView()");
+        }
+
         if (!isInitialized() || isDestroyed()) {
             TiLog.v(TAG, "not calling onDestroy(), destroy was already called");
             return;

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/ActivityInstanceObserver.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/ActivityInstanceObserver.java
@@ -26,25 +26,24 @@ import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 
 import java.util.HashMap;
-import java.util.UUID;
 
 /**
- * Keeps track of {@link Activity}s across orientation changes using a unique id when added via
- * {@link #startTracking(Activity)}. When the {@link Activity} finishes the {@link Listener} is
- * triggered.
+ * Keeps track of {@link Activity}s across orientation changes using a id when added via
+ * {@link #startTracking(Activity, String)}. When the {@link Activity} finishes the
+ * {@link ActivityFinishListener} is triggered.
  */
 public class ActivityInstanceObserver implements Application.ActivityLifecycleCallbacks {
 
     /**
      * Callback when an {@link Activity} will be completely destroyed
      */
-    public interface Listener {
+    public interface ActivityFinishListener {
 
         /**
          * called when the {@link Activity} finishes completely. Doesn't get called when the
          * Activity changes its configuration
          */
-        void onActivityFinished(final Activity activity, final String activityId);
+        void onActivityFinished(final Activity activity, final String hostId);
     }
 
     @VisibleForTesting
@@ -52,16 +51,16 @@ public class ActivityInstanceObserver implements Application.ActivityLifecycleCa
 
     private static final String TAG = ActivityInstanceObserver.class.getSimpleName();
 
-    private Listener mListener;
+    private ActivityFinishListener mListener;
 
     private final HashMap<Activity, String> mScopeIdForActivity = new HashMap<>();
 
-    public ActivityInstanceObserver(@NonNull final Listener listener) {
+    public ActivityInstanceObserver(@NonNull final ActivityFinishListener listener) {
         mListener = listener;
     }
 
     /**
-     * Returns the id created with {@link #startTracking(Activity)}
+     * Returns the id created with {@link #startTracking(Activity, String)}
      *
      * @return a unique id for each {@link Activity} which doesn't change when the {@link Activity}
      * changes its configuration
@@ -131,17 +130,13 @@ public class ActivityInstanceObserver implements Application.ActivityLifecycleCa
     }
 
     /**
-     * tracks the Activity over orientation changes using a unique id. Use
-     * {@link #getActivityId(Activity)} to get the current Activity instance with the id returned
-     * from this method
+     * tracks the Activity over orientation changes using the passed in id. Use
+     * {@link #getActivityId(Activity)} to get the current Activity instance with the id
      *
      * @param activity to be tracked {@link Activity}
-     * @return a unique id for this Activity
      * @see #getActivityId(Activity)
      */
-    public String startTracking(final Activity activity) {
-        final String activityId = UUID.randomUUID().toString();
+    public void startTracking(final Activity activity, final String activityId) {
         mScopeIdForActivity.put(activity, activityId);
-        return activityId;
     }
 }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/ActivityInstanceObserver.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/ActivityInstanceObserver.java
@@ -60,7 +60,7 @@ public class ActivityInstanceObserver implements Application.ActivityLifecycleCa
     }
 
     /**
-     * Returns the id created with {@link #startTracking(Activity, String)}
+     * Returns the id provided by {@link #startTracking(Activity, String)}
      *
      * @return a unique id for each {@link Activity} which doesn't change when the {@link Activity}
      * changes its configuration

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/DelegatedTiActivity.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/DelegatedTiActivity.java
@@ -26,6 +26,14 @@ import java.util.concurrent.Executor;
 public interface DelegatedTiActivity<P> {
 
     /**
+     * This Object is used identify the correct scope where the presenter should be saved in the
+     * {@link PresenterSavior}. This object is only used for identity comparison.
+     *
+     * @return the {@link Activity} instance itself, which is it's own host
+     */
+    Object getHostingContainer();
+
+    /**
      * @return {@link UiThreadExecutor}
      */
     Executor getUiThreadExecutor();
@@ -39,9 +47,4 @@ public interface DelegatedTiActivity<P> {
      * @return {@link Activity#isFinishing()}
      */
     boolean isActivityFinishing();
-
-    /**
-     * @return the Activity itself instance
-     */
-    Activity getHostingActivity();
 }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/DelegatedTiFragment.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/DelegatedTiFragment.java
@@ -15,12 +15,19 @@
 
 package net.grandcentrix.thirtyinch.internal;
 
-import android.app.Activity;
 import android.support.v4.app.Fragment;
 
 import java.util.concurrent.Executor;
 
 public interface DelegatedTiFragment {
+
+    /**
+     * This Object is used identify the correct scope where the presenter should be saved in the
+     * {@link PresenterSavior}. This object is only used for identity comparison.
+     *
+     * @return the object hosting this {@link Fragment}, most likely {@link Fragment#getHost()}
+     */
+    Object getHostingContainer();
 
     /**
      * @return {@link UiThreadExecutor}
@@ -38,28 +45,13 @@ public interface DelegatedTiFragment {
     boolean isFragmentDetached();
 
     /**
-     * @return {@link Fragment#isRemoving()}
-     */
-    boolean isFragmentRemoving();
-
-    /**
-     * @return {@link Activity#isChangingConfigurations()}
-     */
-    boolean isHostingActivityChangingConfigurations();
-
-    /**
-     * @return {@link Activity#isFinishing()}
-     */
-    boolean isHostingActivityFinishing();
-
-    /**
      * @return {@link Fragment#isInBackStack()}
      */
     boolean isFragmentInBackstack();
 
     /**
-     * @return the hosting Activity
+     * @return {@link Fragment#isRemoving()}
      */
-    Activity getHostingActivity();
+    boolean isFragmentRemoving();
 
 }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/PresenterSavior.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/PresenterSavior.java
@@ -124,7 +124,12 @@ public class PresenterSavior implements TiPresenterSavior,
 
                 // when the presenter is not destroyed yet, destroy it.
                 if (!presenter.isDestroyed()) {
-                    presenter.destroy();
+                    if (presenter.isViewAttached()) {
+                        presenter.detachView();
+                    }
+                    if (!presenter.isDestroyed()) {
+                        presenter.destroy();
+                    }
                 }
                 scope.remove(presenterId);
             }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/PresenterScope.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/PresenterScope.java
@@ -26,14 +26,14 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Simple wrapper around a {@link HashMap} to save {@link TiPresenter} by id. For every {@link
- * android.app.Activity} containing a {@link TiPresenter} a corresponding {@link
- * ActivityScopedPresenters} will be created. It contains the {@link TiPresenter} of the Activity
- * itself and of all of its Fragments.
+ * Simple wrapper around a {@link HashMap} to save {@link TiPresenter} by id. For every host of a
+ * {@link TiPresenter} (i.e. {@link android.app.Activity}) a corresponding {@link PresenterScope}
+ * will be created.
+ * It contains the {@link TiPresenter} of the Activity itself and of all of its Fragments.
  */
-public class ActivityScopedPresenters {
+public class PresenterScope {
 
-    private final String TAG = ActivityScopedPresenters.class.getSimpleName()
+    private final String TAG = PresenterScope.class.getSimpleName()
             + "@" + Integer.toHexString(hashCode());
 
     private final HashMap<String, TiPresenter> mStore = new HashMap<>();

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegate.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegate.java
@@ -145,7 +145,7 @@ public class TiActivityDelegate<P extends TiPresenter<V>, V extends TiView>
                     TiLog.v(mLogTag.getLoggingTag(),
                             "try to recover Presenter with id: " + recoveredPresenterId);
                     mPresenter = (P) mSavior
-                            .recover(recoveredPresenterId, mTiActivity.getHostingActivity());
+                            .recover(recoveredPresenterId, mTiActivity.getHostingContainer());
                     TiLog.v(mLogTag.getLoggingTag(),
                             "recovered Presenter from savior " + mPresenter);
                 } else {
@@ -161,8 +161,8 @@ public class TiActivityDelegate<P extends TiPresenter<V>, V extends TiView>
                 // save recovered presenter with new id. No other instance of this activity,
                 // holding the presenter before, is now able to remove the reference to
                 // this presenter from the savior
-                mSavior.free(recoveredPresenterId, mTiActivity.getHostingActivity());
-                mPresenterId = mSavior.save(mPresenter, mTiActivity.getHostingActivity());
+                mSavior.free(recoveredPresenterId, mTiActivity.getHostingContainer());
+                mPresenterId = mSavior.save(mPresenter, mTiActivity.getHostingContainer());
             }
         }
 
@@ -178,7 +178,7 @@ public class TiActivityDelegate<P extends TiPresenter<V>, V extends TiView>
             TiLog.v(mLogTag.getLoggingTag(), "created Presenter: " + mPresenter);
             final TiConfiguration config = mPresenter.getConfig();
             if (config.shouldRetainPresenter()) {
-                mPresenterId = mSavior.save(mPresenter, mTiActivity.getHostingActivity());
+                mPresenterId = mSavior.save(mPresenter, mTiActivity.getHostingContainer());
             }
             mPresenter.create();
         }
@@ -229,7 +229,7 @@ public class TiActivityDelegate<P extends TiPresenter<V>, V extends TiView>
 
         if (destroyPresenter) {
             mPresenter.destroy();
-            mSavior.free(mPresenterId, mTiActivity.getHostingActivity());
+            mSavior.free(mPresenterId, mTiActivity.getHostingContainer());
         } else {
             TiLog.v(mLogTag.getLoggingTag(), "not destroying " + mPresenter
                     + " which will be reused by the next Activity instance, recreating...");

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiFragmentDelegate.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiFragmentDelegate.java
@@ -216,15 +216,6 @@ public class TiFragmentDelegate<P extends TiPresenter<V>, V extends TiView>
             TiLog.v(mLogTag.getLoggingTag(), "fragment is in backstack");
         }
 
-        if (mTiFragment.isHostingActivityFinishing()
-                && !mTiFragment.isHostingActivityChangingConfigurations()) {
-            // Probably a backpress and not a configuration change
-            // Activity will not be recreated and finally destroyed, also destroyed the presenter
-            destroyPresenter = true;
-            TiLog.v(mLogTag.getLoggingTag(),
-                    "Hosting Activity is finishing, destroying presenter " + mPresenter);
-        }
-
         if (!destroyPresenter &&
                 !mPresenter.getConfig().shouldRetainPresenter()) {
             // configuration says the presenter should not be retained, a new presenter instance

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiFragmentDelegate.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiFragmentDelegate.java
@@ -144,13 +144,13 @@ public class TiFragmentDelegate<P extends TiPresenter<V>, V extends TiView>
                 TiLog.v(mLogTag.getLoggingTag(),
                         "try to recover Presenter with id: " + recoveredPresenterId);
                 mPresenter = (P) mSavior
-                        .recover(recoveredPresenterId, mTiFragment.getHostingActivity());
+                        .recover(recoveredPresenterId, mTiFragment.getHostingContainer());
                 if (mPresenter != null) {
                     // save recovered presenter with new id. No other instance of this activity,
                     // holding the presenter before, is now able to remove the reference to
                     // this presenter from the savior
-                    mSavior.free(recoveredPresenterId, mTiFragment.getHostingActivity());
-                    mPresenterId = mSavior.save(mPresenter, mTiFragment.getHostingActivity());
+                    mSavior.free(recoveredPresenterId, mTiFragment.getHostingContainer());
+                    mPresenterId = mSavior.save(mPresenter, mTiFragment.getHostingContainer());
                 }
                 TiLog.v(mLogTag.getLoggingTag(), "recovered Presenter " + mPresenter);
             }
@@ -167,7 +167,7 @@ public class TiFragmentDelegate<P extends TiPresenter<V>, V extends TiView>
             TiLog.v(mLogTag.getLoggingTag(), "created Presenter: " + mPresenter);
             final TiConfiguration config = mPresenter.getConfig();
             if (config.shouldRetainPresenter()) {
-                mPresenterId = mSavior.save(mPresenter, mTiFragment.getHostingActivity());
+                mPresenterId = mSavior.save(mPresenter, mTiFragment.getHostingContainer());
             }
             mPresenter.create();
         }
@@ -236,7 +236,7 @@ public class TiFragmentDelegate<P extends TiPresenter<V>, V extends TiView>
 
         if (destroyPresenter) {
             mPresenter.destroy();
-            mSavior.free(mPresenterId, mTiFragment.getHostingActivity());
+            mSavior.free(mPresenterId, mTiFragment.getHostingContainer());
         } else {
             TiLog.v(mLogTag.getLoggingTag(), "not destroying " + mPresenter
                     + " which will be reused by a future Fragment instance");

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiPresenterSavior.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiPresenterSavior.java
@@ -21,6 +21,7 @@ import net.grandcentrix.thirtyinch.TiPresenter;
 import android.app.Activity;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
 
 /**
  * Store for presenters to survive when their associated context gets destroyed (e.g. Activity or
@@ -32,23 +33,28 @@ public interface TiPresenterSavior {
      * Frees a certain presenter from the store.
      *
      * @param presenterId the id of the presenter
+     * @param host        host of the presenter, see {@link #save(TiPresenter, Object)}
      */
-    void free(String presenterId, @NonNull Activity activity);
+    void free(String presenterId, @NonNull Object host);
 
     /**
      * Gets a presenter from the store.
      *
      * @param presenterId the id of the presenter
+     * @param host        host of the presenter, see {@link #save(TiPresenter, Object)}
      * @return the presenter of {@code null} if no presenter could be found
      */
     @Nullable
-    TiPresenter recover(String presenterId, @NonNull Activity activity);
+    TiPresenter recover(String presenterId, @NonNull Object host);
 
     /**
-     * Stores a presenter in the store.
+     * Stores a presenter in the store for a given host. When the host gets destroyed the presenter
+     * will be destroyed automatically. For {@link Activity} the host is the {@link Activity}
+     * itself, for {@link Fragment} the host is {@link Fragment#getHost()}
      *
      * @param presenter the presenter that should be stored
+     * @param host      host of the presenter
      * @return the id of the stored presenter
      */
-    String save(@NonNull TiPresenter presenter, @NonNull Activity activity);
+    String save(@NonNull TiPresenter presenter, @NonNull Object host);
 }

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/TiPresenterTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/TiPresenterTest.java
@@ -110,6 +110,21 @@ public class TiPresenterTest {
     }
 
     @Test
+    public void destroyPresenterWithAttachedView() throws Exception {
+        mPresenter.create();
+        mPresenter.attachView(mView);
+
+        try {
+            mPresenter.destroy();
+            fail("error expected");
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage().contains("attached"));
+            assertTrue(e.getMessage().contains("detachView()"));
+        }
+
+    }
+
+    @Test
     public void destroyWithoutAttachingView() throws Exception {
         mPresenter.create();
         mPresenter.destroy();

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/MultipleTiFragmentPresenterDestroyTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/MultipleTiFragmentPresenterDestroyTest.java
@@ -38,7 +38,6 @@ public class MultipleTiFragmentPresenterDestroyTest extends AbstractPresenterDes
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -81,7 +80,6 @@ public class MultipleTiFragmentPresenterDestroyTest extends AbstractPresenterDes
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -129,7 +127,6 @@ public class MultipleTiFragmentPresenterDestroyTest extends AbstractPresenterDes
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -175,7 +172,6 @@ public class MultipleTiFragmentPresenterDestroyTest extends AbstractPresenterDes
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -220,7 +216,6 @@ public class MultipleTiFragmentPresenterDestroyTest extends AbstractPresenterDes
                 .build());
 
         final TestTiFragment fragment2 = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity2)
                 .setSavior(mSavior)
                 .setPresenter(presenter2)
@@ -250,7 +245,6 @@ public class MultipleTiFragmentPresenterDestroyTest extends AbstractPresenterDes
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -313,7 +307,6 @@ public class MultipleTiFragmentPresenterDestroyTest extends AbstractPresenterDes
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -374,7 +367,6 @@ public class MultipleTiFragmentPresenterDestroyTest extends AbstractPresenterDes
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -405,6 +397,7 @@ public class MultipleTiFragmentPresenterDestroyTest extends AbstractPresenterDes
         // When the activity finishes
         // nothing happens because the presenter is already destroyed
         hostingActivity.setFinishing(true);
+        assertThat(mSavior.mActivityInstanceObserver).isNull();
     }
 
     @Test
@@ -419,7 +412,6 @@ public class MultipleTiFragmentPresenterDestroyTest extends AbstractPresenterDes
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -444,6 +436,7 @@ public class MultipleTiFragmentPresenterDestroyTest extends AbstractPresenterDes
 
         // When the Activity is finishing.
         hostingActivity.setFinishing(true);
+        assertThat(mSavior.mActivityInstanceObserver).isNull();
         fragment.onDestroy();
 
         // Then the Presenter is destroyed and not saved in the savior.
@@ -466,7 +459,6 @@ public class MultipleTiFragmentPresenterDestroyTest extends AbstractPresenterDes
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -497,6 +489,7 @@ public class MultipleTiFragmentPresenterDestroyTest extends AbstractPresenterDes
         // When the activity finishes
         // nothing happens because the presenter is already destroyed
         hostingActivity.setFinishing(true);
+        assertThat(mSavior.mActivityInstanceObserver).isNull();
     }
 
     /**
@@ -514,7 +507,6 @@ public class MultipleTiFragmentPresenterDestroyTest extends AbstractPresenterDes
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -539,6 +531,8 @@ public class MultipleTiFragmentPresenterDestroyTest extends AbstractPresenterDes
 
         // And when the Activity is finishing.
         hostingActivity.setFinishing(true);
+        mSavior.mActivityInstanceObserver.onActivityDestroyed(
+                hostingActivity.getMockActivityInstance());
         fragment.onDestroy();
 
         // Then assert that the Presenter is destroyed and not saved in the savior.
@@ -558,7 +552,6 @@ public class MultipleTiFragmentPresenterDestroyTest extends AbstractPresenterDes
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -604,7 +597,6 @@ public class MultipleTiFragmentPresenterDestroyTest extends AbstractPresenterDes
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities.java
@@ -44,7 +44,6 @@ public class MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -78,7 +77,6 @@ public class MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -119,7 +117,6 @@ public class MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -162,7 +159,6 @@ public class MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -207,7 +203,6 @@ public class MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities
                 .build());
 
         final TestTiFragment fragment2 = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity2)
                 .setSavior(mSavior)
                 .setPresenter(presenter2)
@@ -237,7 +232,6 @@ public class MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -299,7 +293,6 @@ public class MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -359,7 +352,6 @@ public class MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -390,6 +382,7 @@ public class MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities
         // When the activity finishes
         // nothing happens because the presenter is already destroyed
         hostingActivity.setFinishing(true);
+        assertThat(mSavior.mActivityInstanceObserver).isNull();
     }
 
     @Test
@@ -404,7 +397,6 @@ public class MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -425,6 +417,7 @@ public class MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities
 
         // And when the Activity is finishing.
         hostingActivity.setFinishing(true);
+        assertThat(mSavior.mActivityInstanceObserver).isNull();
         fragment.onDestroy();
 
         // Then assert that the Presenter is destroyed and not saved in the savior.
@@ -444,7 +437,6 @@ public class MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -471,6 +463,7 @@ public class MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities
         // When the activity finishes
         // nothing happens because the presenter is already destroyed
         hostingActivity.setFinishing(true);
+        assertThat(mSavior.mActivityInstanceObserver).isNull();
     }
 
     @Test
@@ -485,7 +478,6 @@ public class MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -506,6 +498,8 @@ public class MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities
 
         // And when the Activity is finishing.
         hostingActivity.setFinishing(true);
+        mSavior.mActivityInstanceObserver.onActivityDestroyed(
+                hostingActivity.getMockActivityInstance());
         fragment.onDestroy();
 
         // Then assert that the Presenter is destroyed and not saved in the savior.
@@ -525,7 +519,6 @@ public class MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -568,7 +561,6 @@ public class MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/PresenterSaviorTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/PresenterSaviorTest.java
@@ -28,6 +28,7 @@ import android.support.annotation.NonNull;
 import java.util.HashMap;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Java6Assertions.fail;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -292,6 +293,18 @@ public class PresenterSaviorTest {
     }
 
     @Test
+    public void recoverUnsupportedHost() throws Exception {
+        final TestPresenterSavior savior = new TestPresenterSavior();
+        try {
+            savior.recover("someRandomId", "not supported host");
+            fail("did not throw");
+        } catch (Throwable e) {
+            assertThat(e).isInstanceOf(PresenterSavior.IllegalHostException.class)
+                    .hasMessageContaining("String");
+        }
+    }
+
+    @Test
     public void restoreFailWithDifferentActivity() throws Exception {
 
         final TestPresenterSavior savior = new TestPresenterSavior();
@@ -336,6 +349,20 @@ public class PresenterSaviorTest {
         final String id = savior.save(presenter, hostingActivity.getMockActivityInstance());
         assertThat(savior.getPresenterCount()).isEqualTo(1);
         assertThat(id).isNotEmpty().isNotNull();
+    }
+
+    @Test
+    public void saveUnsupportedHost() throws Exception {
+        final TestPresenterSavior savior = new TestPresenterSavior();
+        final TiPresenter presenter = new TiPresenter() {
+        };
+        try {
+            savior.save(presenter, "not supported host");
+            fail("did not throw");
+        } catch (Throwable e) {
+            assertThat(e).isInstanceOf(PresenterSavior.IllegalHostException.class)
+                    .hasMessageContaining("String");
+        }
     }
 
     @Before

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/SingleTiFragmentPresenterDestroyTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/SingleTiFragmentPresenterDestroyTest.java
@@ -44,7 +44,6 @@ public class SingleTiFragmentPresenterDestroyTest extends AbstractPresenterDestr
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -81,7 +80,6 @@ public class SingleTiFragmentPresenterDestroyTest extends AbstractPresenterDestr
                 .setRetainPresenterEnabled(false)
                 .build());
         final TestTiFragment fragment2 = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity2)
                 .setSavior(mSavior)
                 .setPresenter(presenter2)
@@ -118,7 +116,6 @@ public class SingleTiFragmentPresenterDestroyTest extends AbstractPresenterDestr
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -156,7 +153,6 @@ public class SingleTiFragmentPresenterDestroyTest extends AbstractPresenterDestr
                 .setRetainPresenterEnabled(false)
                 .build());
         final TestTiFragment fragment2 = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity2)
                 .setSavior(mSavior)
                 .setPresenter(presenter2)
@@ -189,7 +185,6 @@ public class SingleTiFragmentPresenterDestroyTest extends AbstractPresenterDestr
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -206,6 +201,7 @@ public class SingleTiFragmentPresenterDestroyTest extends AbstractPresenterDestr
 
         // And when the Activity is finishing.
         hostingActivity.setFinishing(true);
+        assertThat(mSavior.mActivityInstanceObserver).isNull();
         fragment.onStop();
         fragment.onDestroyView();
         fragment.onDestroy();
@@ -235,7 +231,6 @@ public class SingleTiFragmentPresenterDestroyTest extends AbstractPresenterDestr
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -252,6 +247,8 @@ public class SingleTiFragmentPresenterDestroyTest extends AbstractPresenterDestr
 
         // And when the Activity is finishing.
         hostingActivity.setFinishing(true);
+        mSavior.mActivityInstanceObserver.onActivityDestroyed(
+                hostingActivity.getMockActivityInstance());
         fragment.onStop();
         fragment.onDestroyView();
         fragment.onDestroy();
@@ -276,7 +273,6 @@ public class SingleTiFragmentPresenterDestroyTest extends AbstractPresenterDestr
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -326,7 +322,6 @@ public class SingleTiFragmentPresenterDestroyTest extends AbstractPresenterDestr
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -373,7 +368,6 @@ public class SingleTiFragmentPresenterDestroyTest extends AbstractPresenterDestr
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -415,7 +409,6 @@ public class SingleTiFragmentPresenterDestroyTest extends AbstractPresenterDestr
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -466,7 +459,6 @@ public class SingleTiFragmentPresenterDestroyTest extends AbstractPresenterDestr
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -508,7 +500,6 @@ public class SingleTiFragmentPresenterDestroyTest extends AbstractPresenterDestr
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -559,7 +550,6 @@ public class SingleTiFragmentPresenterDestroyTest extends AbstractPresenterDestr
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenterProvider(new TiPresenterProvider<TiPresenter<TiView>>() {
@@ -620,7 +610,6 @@ public class SingleTiFragmentPresenterDestroyTest extends AbstractPresenterDestr
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(false)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenterProvider(new TiPresenterProvider<TiPresenter<TiView>>() {

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/SingleTiFragmentPresenterDestroyTestIgnoreKeepDontKeepActivities.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/SingleTiFragmentPresenterDestroyTestIgnoreKeepDontKeepActivities.java
@@ -50,7 +50,6 @@ public class SingleTiFragmentPresenterDestroyTestIgnoreKeepDontKeepActivities
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -86,7 +85,6 @@ public class SingleTiFragmentPresenterDestroyTestIgnoreKeepDontKeepActivities
                 .setRetainPresenterEnabled(false)
                 .build());
         final TestTiFragment fragment2 = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity2)
                 .setSavior(mSavior)
                 .setPresenter(presenter2)
@@ -118,7 +116,6 @@ public class SingleTiFragmentPresenterDestroyTestIgnoreKeepDontKeepActivities
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -156,7 +153,6 @@ public class SingleTiFragmentPresenterDestroyTestIgnoreKeepDontKeepActivities
                 .setRetainPresenterEnabled(false)
                 .build());
         final TestTiFragment fragment2 = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity2)
                 .setSavior(mSavior)
                 .setPresenter(presenter2)
@@ -189,7 +185,6 @@ public class SingleTiFragmentPresenterDestroyTestIgnoreKeepDontKeepActivities
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -206,6 +201,7 @@ public class SingleTiFragmentPresenterDestroyTestIgnoreKeepDontKeepActivities
 
         // And when the Activity is finishing.
         hostingActivity.setFinishing(true);
+        assertThat(mSavior.mActivityInstanceObserver).isNull();
         fragment.onStop();
         fragment.onDestroyView();
         fragment.onDestroy();
@@ -233,7 +229,6 @@ public class SingleTiFragmentPresenterDestroyTestIgnoreKeepDontKeepActivities
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -250,6 +245,8 @@ public class SingleTiFragmentPresenterDestroyTestIgnoreKeepDontKeepActivities
 
         // And when the Activity is finishing.
         hostingActivity.setFinishing(true);
+        mSavior.mActivityInstanceObserver.onActivityDestroyed(
+                hostingActivity.getMockActivityInstance());
         fragment.onStop();
         fragment.onDestroyView();
         fragment.onDestroy();
@@ -275,7 +272,6 @@ public class SingleTiFragmentPresenterDestroyTestIgnoreKeepDontKeepActivities
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -309,7 +305,6 @@ public class SingleTiFragmentPresenterDestroyTestIgnoreKeepDontKeepActivities
                 .setRetainPresenterEnabled(false)
                 .build());
         final TestTiFragment fragment2 = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity2)
                 .setSavior(mSavior)
                 .setPresenter(presenter2)
@@ -341,7 +336,6 @@ public class SingleTiFragmentPresenterDestroyTestIgnoreKeepDontKeepActivities
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -379,7 +373,6 @@ public class SingleTiFragmentPresenterDestroyTestIgnoreKeepDontKeepActivities
                 .setRetainPresenterEnabled(false)
                 .build());
         final TestTiFragment fragment2 = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity2)
                 .setSavior(mSavior)
                 .setPresenter(presenter2)
@@ -412,7 +405,6 @@ public class SingleTiFragmentPresenterDestroyTestIgnoreKeepDontKeepActivities
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -454,7 +446,6 @@ public class SingleTiFragmentPresenterDestroyTestIgnoreKeepDontKeepActivities
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenter(presenter)
@@ -496,7 +487,6 @@ public class SingleTiFragmentPresenterDestroyTestIgnoreKeepDontKeepActivities
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenterProvider(new TiPresenterProvider<TiPresenter<TiView>>() {
@@ -557,7 +547,6 @@ public class SingleTiFragmentPresenterDestroyTestIgnoreKeepDontKeepActivities
 
         // And given a Fragment.
         final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setDontKeepActivitiesEnabled(true)
                 .setHostingActivity(hostingActivity)
                 .setSavior(mSavior)
                 .setPresenterProvider(new TiPresenterProvider<TiPresenter<TiView>>() {

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/TestPresenterSavior.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/TestPresenterSavior.java
@@ -27,7 +27,7 @@ public class TestPresenterSavior extends PresenterSavior {
         }
 
         int size = 0;
-        for (final ActivityScopedPresenters scope : mScopes.values()) {
+        for (final PresenterScope scope : mScopes.values()) {
             size += scope.size();
         }
         return size;

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/TestTiActivity.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/TestTiActivity.java
@@ -95,7 +95,11 @@ public class TestTiActivity
     }
 
     @Override
-    public Activity getHostingActivity() {
+    public Object getHostingContainer() {
+        return mHostingActivity.getMockActivityInstance();
+    }
+
+    public Activity getMockActivityInstance() {
         return mHostingActivity.getMockActivityInstance();
     }
 

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/TestTiFragment.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/TestTiFragment.java
@@ -19,7 +19,6 @@ package net.grandcentrix.thirtyinch.internal;
 import net.grandcentrix.thirtyinch.TiPresenter;
 import net.grandcentrix.thirtyinch.TiView;
 
-import android.app.Activity;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.view.LayoutInflater;
@@ -42,8 +41,6 @@ public class TestTiFragment
 
         private HostingActivity mHostingActivity = new HostingActivity();
 
-        private boolean mIsDontKeepActivitiesEnabled = false;
-
         private TiPresenter<TiView> mPresenter;
 
         private TiPresenterProvider<TiPresenter<TiView>> mPresenterProvider;
@@ -62,13 +59,7 @@ public class TestTiFragment
                 };
             }
 
-            return new TestTiFragment(presenterProvider, mIsDontKeepActivitiesEnabled, mSavior,
-                    mHostingActivity);
-        }
-
-        public Builder setDontKeepActivitiesEnabled(final boolean enabled) {
-            mIsDontKeepActivitiesEnabled = enabled;
-            return this;
+            return new TestTiFragment(presenterProvider, mSavior, mHostingActivity);
         }
 
         public Builder setHostingActivity(final HostingActivity hostingActivity) {
@@ -103,12 +94,9 @@ public class TestTiFragment
 
     private boolean mInBackstack;
 
-    private boolean mIsDontKeepActivitiesEnabled;
-
     private boolean mRemoving;
 
     private TestTiFragment(final TiPresenterProvider<TiPresenter<TiView>> presenterProvider,
-            final boolean isDontKeepActivitiesEnabled,
             final TiPresenterSavior savior,
             final HostingActivity hostingActivity) {
 
@@ -120,12 +108,11 @@ public class TestTiFragment
                     }
                 }, savior);
 
-        mIsDontKeepActivitiesEnabled = isDontKeepActivitiesEnabled;
         mHostingActivity = hostingActivity;
     }
 
     @Override
-    public Activity getHostingActivity() {
+    public Object getHostingContainer() {
         return mHostingActivity.getMockActivityInstance();
     }
 
@@ -155,23 +142,13 @@ public class TestTiFragment
     }
 
     @Override
-    public boolean isFragmentRemoving() {
-        return mRemoving;
-    }
-
-    @Override
-    public boolean isHostingActivityChangingConfigurations() {
-        return mHostingActivity.isChangingConfiguration();
-    }
-
-    @Override
-    public boolean isHostingActivityFinishing() {
-        return mHostingActivity.isFinishing();
-    }
-
-    @Override
     public boolean isFragmentInBackstack() {
         return mInBackstack;
+    }
+
+    @Override
+    public boolean isFragmentRemoving() {
+        return mRemoving;
     }
 
     public void onCreate(final Bundle saveInstanceState) {

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/TiActivityPresenterDestroyTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/TiActivityPresenterDestroyTest.java
@@ -152,7 +152,7 @@ public class TiActivityPresenterDestroyTest extends AbstractPresenterDestroyTest
         activity.setChangingConfiguration(true);
         activity.onStop();
         mSavior.mActivityInstanceObserver.onActivitySaveInstanceState(
-                activity.getHostingActivity(), mActivitySavedState);
+                activity.getMockActivityInstance(), mActivitySavedState);
         activity.onSaveInstanceState(mActivitySavedState);
         activity.onDestroy();
 
@@ -167,7 +167,7 @@ public class TiActivityPresenterDestroyTest extends AbstractPresenterDestroyTest
 
         // When the new Activity instance gets created
         mSavior.mActivityInstanceObserver.onActivityCreated(
-                activity2.getHostingActivity(), mActivitySavedState);
+                activity2.getMockActivityInstance(), mActivitySavedState);
         activity2.onCreate(mActivitySavedState);
         activity2.onStart();
 
@@ -201,7 +201,7 @@ public class TiActivityPresenterDestroyTest extends AbstractPresenterDestroyTest
         activity.setChangingConfiguration(true);
         activity.onStop();
         mSavior.mActivityInstanceObserver.onActivitySaveInstanceState(
-                activity.getHostingActivity(), mActivitySavedState);
+                activity.getMockActivityInstance(), mActivitySavedState);
         activity.onSaveInstanceState(mActivitySavedState);
         activity.onDestroy();
 
@@ -216,7 +216,7 @@ public class TiActivityPresenterDestroyTest extends AbstractPresenterDestroyTest
 
         // When the new Activity instance gets created
         mSavior.mActivityInstanceObserver.onActivityCreated(
-                activity2.getHostingActivity(), mActivitySavedState);
+                activity2.getMockActivityInstance(), mActivitySavedState);
         activity2.onCreate(mActivitySavedState);
         activity2.onStart();
 
@@ -321,7 +321,7 @@ public class TiActivityPresenterDestroyTest extends AbstractPresenterDestroyTest
         activity.setChangingConfiguration(false);
         activity.onStop();
         mSavior.mActivityInstanceObserver.onActivitySaveInstanceState(
-                activity.getHostingActivity(), mActivitySavedState);
+                activity.getMockActivityInstance(), mActivitySavedState);
         activity.onSaveInstanceState(mActivitySavedState);
         activity.onDestroy();
 
@@ -356,7 +356,7 @@ public class TiActivityPresenterDestroyTest extends AbstractPresenterDestroyTest
         activity.setChangingConfiguration(false);
         activity.onStop();
         mSavior.mActivityInstanceObserver.onActivitySaveInstanceState(
-                activity.getHostingActivity(), mActivitySavedState);
+                activity.getMockActivityInstance(), mActivitySavedState);
         activity.onSaveInstanceState(mActivitySavedState);
         activity.onDestroy();
 
@@ -478,7 +478,7 @@ public class TiActivityPresenterDestroyTest extends AbstractPresenterDestroyTest
         activity.setChangingConfiguration(false);
         activity.onStop();
         mSavior.mActivityInstanceObserver.onActivitySaveInstanceState(
-                activity.getHostingActivity(), mActivitySavedState);
+                activity.getMockActivityInstance(), mActivitySavedState);
 
         // Then the presenter is not destroyed
         assertThat(presenter.isDestroyed()).isFalse();
@@ -514,7 +514,7 @@ public class TiActivityPresenterDestroyTest extends AbstractPresenterDestroyTest
         activity.setChangingConfiguration(false);
         activity.onStop();
         mSavior.mActivityInstanceObserver.onActivitySaveInstanceState(
-                activity.getHostingActivity(), mActivitySavedState);
+                activity.getMockActivityInstance(), mActivitySavedState);
         activity.onSaveInstanceState(mActivitySavedState);
         activity.onDestroy();
 
@@ -529,7 +529,7 @@ public class TiActivityPresenterDestroyTest extends AbstractPresenterDestroyTest
 
         // When the new Activity instance gets created
         mSavior.mActivityInstanceObserver.onActivityCreated(
-                activity2.getHostingActivity(), mActivitySavedState);
+                activity2.getMockActivityInstance(), mActivitySavedState);
         activity2.onCreate(mActivitySavedState);
         assertThat(activity2.getPresenter().isInitialized()).isTrue();
         activity2.onStart();


### PR DESCRIPTION
More or less a cleanup PR for #78 

@vRallev pointed out #86 that the naming in `DelegatedTiFragment` is quite confusing. 
- `getHostingActivity()` returns `Activity` but shouldn't used as `Activity` to call methods like `isFinishing()`. 
- `isHostingActivityFinishing()` doesn't read the `isFinishing()` property from `getHostingActivity()`
- `isHostingActivityChangingConfigurations()` doesn't read the `isChangingConfigurations()` property from `getHostingActivity()`

Solution:
- `isHostingActivityFinishing()` and `isHostingActivityChangingConfigurations()` can be removed. The `PresenterSavior` is now 100% responsible to destroy the presenter when a `Activity` containing a `TiFragment` finishes.
- `Activity getHostingActivity()` was replaced with `Object getHostingContainer()` in `DelegatedTiFragment` (returning `Fragment#getHost()`) and `DelegatedTiActivity` (returning itself)

Also:
- `PresenterSavior` calls now all `TiPresenter` destructing methods including `detachView()`
- Fixed bug where `TiPresenter#destroy()` didn't destroy the presenter when the view is attached
- Removed `TestTiFragment.Builder#setDontKeepActivitiesEnabled(boolean)` which actually did nothing.
- Fix missing overrides for `TiDialogFragment`


