### PR TITLE
Fix some javadoc warnings

### DIFF
--- a/logginginterceptor/src/main/java/net/grandcentrix/thirtyinch/logginginterceptor/LoggingInterceptor.java
+++ b/logginginterceptor/src/main/java/net/grandcentrix/thirtyinch/logginginterceptor/LoggingInterceptor.java
@@ -153,7 +153,8 @@ public class LoggingInterceptor implements BindViewInterceptor {
     }
 
     /**
-     * Logs all view interface method invocations to the provided {@link TiLog.Logger} interface
+     * Logs all view interface method invocations to the provided
+     * {@link net.grandcentrix.thirtyinch.TiLog.Logger} interface
      *
      * @param logger custom logger, {@link TiLog#LOGCAT} or {@link TiLog#NOOP} to disable logging.
      */

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
@@ -83,7 +83,7 @@ import java.util.concurrent.Executor;
  * </p>
  *
  * @param <V> the View type, must implement {@link TiView}
- * @param <P> the Presenter type, must extend {@link TiPresenter<V>}
+ * @param <P> the Presenter type, must extend {@link TiPresenter}
  */
 public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
         extends AppCompatActivity

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiFragment.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiFragment.java
@@ -105,7 +105,7 @@ import java.util.concurrent.Executor;
  * </p>
  *
  * @param <V> the View type, must implement {@link TiView}
- * @param <P> the Presenter type, must extend {@link TiPresenter<V>}
+ * @param <P> the Presenter type, must extend {@link TiPresenter}
  */
 public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView> extends Fragment
         implements DelegatedTiFragment, TiPresenterProvider<P>, TiLoggingTagProvider,

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
@@ -24,6 +24,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 import android.support.v4.app.Fragment;
+import android.widget.Toast;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -496,8 +497,8 @@ public abstract class TiPresenter<V extends TiView> {
      * When the view is already attached the action will be executed immediately.
      * <p>
      * This method might be very useful for single actions which invoke function like {@link
-     * Activity#finish()}, {@link Activity#startActivity(Intent)} or showing a {@link
-     * android.widget.Toast} in the view.
+     * Activity#finish()}, {@link Activity#startActivity(Intent)} or showing a {@link Toast} in the
+     * view.
      * <p>
      * <b>But don't overuse it.</b>
      * The action will only be called <b>once</b>.


### PR DESCRIPTION
This will fixes some javadoc warnings we found in #88 
See also #95 

There is one issue left which says:
> src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java:515: warning - Tag @link: reference not found: android.widget.Toast

But I'm unable to fix that 🤷‍♂️
If you can give me a hint - feel free 👍