### PR TITLE
Deprecate/remove changing configuration

### DIFF
--- a/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiActivityPlugin.java
+++ b/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiActivityPlugin.java
@@ -135,11 +135,6 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
     }
 
     @Override
-    public boolean isActivityChangingConfigurations() {
-        return getActivity().isChangingConfigurations();
-    }
-
-    @Override
     public final boolean isActivityFinishing() {
         return getActivity().isFinishing();
     }

--- a/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiActivityPlugin.java
+++ b/plugin/src/main/java/net/grandcentrix/thirtyinch/plugin/TiActivityPlugin.java
@@ -51,7 +51,7 @@ import java.util.concurrent.Executor;
  * @param <V> View, expected by the {@link TiPresenter}
  */
 public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extends ActivityPlugin
-        implements TiViewProvider<V>, DelegatedTiActivity<P>, TiLoggingTagProvider,
+        implements TiViewProvider<V>, DelegatedTiActivity, TiLoggingTagProvider,
         InterceptableViewBinder<V>, PresenterAccessor<P, V> {
 
     private static final String NCI_KEY_PRESENTER = "presenter";
@@ -83,6 +83,11 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
     @Override
     public final Removable addBindViewInterceptor(@NonNull final BindViewInterceptor interceptor) {
         return mDelegate.addBindViewInterceptor(interceptor);
+    }
+
+    @Override
+    public final Object getHostingContainer() {
+        return getActivity();
     }
 
     /**
@@ -137,11 +142,6 @@ public class TiActivityPlugin<P extends TiPresenter<V>, V extends TiView> extend
     @Override
     public final boolean isActivityFinishing() {
         return getActivity().isFinishing();
-    }
-
-    @Override
-    public final Object getHostingContainer() {
-        return getActivity();
     }
 
     @CallSuper

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
@@ -151,11 +151,6 @@ public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
     }
 
     @Override
-    public final boolean isActivityChangingConfigurations() {
-        return isChangingConfigurations();
-    }
-
-    @Override
     public final boolean isActivityFinishing() {
         return isFinishing();
     }

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiActivity.java
@@ -87,7 +87,7 @@ import java.util.concurrent.Executor;
  */
 public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView>
         extends AppCompatActivity
-        implements TiPresenterProvider<P>, TiViewProvider<V>, DelegatedTiActivity<P>,
+        implements TiPresenterProvider<P>, TiViewProvider<V>, DelegatedTiActivity,
         TiLoggingTagProvider, InterceptableViewBinder<V>, PresenterAccessor<P, V> {
 
     private final String TAG = this.getClass().getSimpleName()

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/ActivityInstanceObserver.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/ActivityInstanceObserver.java
@@ -85,9 +85,8 @@ public class ActivityInstanceObserver implements Application.ActivityLifecycleCa
     public void onActivityDestroyed(final Activity activity) {
         TiLog.v(TAG, "destroying " + activity);
         TiLog.v(TAG, "isFinishing = " + activity.isFinishing());
-        TiLog.v(TAG, "isChangingConfigurations = " + activity.isChangingConfigurations());
 
-        if (activity.isFinishing() && !activity.isChangingConfigurations()) {
+        if (activity.isFinishing()) {
             // detected Activity finish, no new Activity instance will be created
             // with savedInstanceState, clear saved presenters
             final String scopeId = mScopeIdForActivity.remove(activity);

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/DelegatedTiActivity.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/DelegatedTiActivity.java
@@ -23,7 +23,7 @@ import java.util.concurrent.Executor;
  * This interface, implemented by Activities allows easy testing of the {@link TiActivityDelegate}
  * without mocking Android classes such as {@link Activity}
  */
-public interface DelegatedTiActivity<P> {
+public interface DelegatedTiActivity {
 
     /**
      * This Object is used identify the correct scope where the presenter should be saved in the

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/DelegatedTiActivity.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/DelegatedTiActivity.java
@@ -39,11 +39,6 @@ public interface DelegatedTiActivity {
     Executor getUiThreadExecutor();
 
     /**
-     * @return {@link Activity#isChangingConfigurations()}
-     */
-    boolean isActivityChangingConfigurations();
-
-    /**
      * @return {@link Activity#isFinishing()}
      */
     boolean isActivityFinishing();

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegate.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegate.java
@@ -209,10 +209,7 @@ public class TiActivityDelegate<P extends TiPresenter<V>, V extends TiView>
         }
 
         boolean destroyPresenter = false;
-        if (mTiActivity.isActivityFinishing()
-                && !mTiActivity.isActivityChangingConfigurations()) {
-            // Probably a backpress and not a configuration change
-            // Activity will not be recreated and finally destroyed, also destroyed the presenter
+        if (mTiActivity.isActivityFinishing()) {
             destroyPresenter = true;
             TiLog.v(mLogTag.getLoggingTag(),
                     "Activity is finishing, destroying presenter " + mPresenter);

--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegate.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/internal/TiActivityDelegate.java
@@ -71,7 +71,7 @@ public class TiActivityDelegate<P extends TiPresenter<V>, V extends TiView>
 
     private final TiPresenterSavior mSavior;
 
-    private final DelegatedTiActivity<P> mTiActivity;
+    private final DelegatedTiActivity mTiActivity;
 
     private Removable mUiThreadBinderRemovable;
 
@@ -79,7 +79,7 @@ public class TiActivityDelegate<P extends TiPresenter<V>, V extends TiView>
 
     private final TiViewProvider<V> mViewProvider;
 
-    public TiActivityDelegate(final DelegatedTiActivity<P> activityProvider,
+    public TiActivityDelegate(final DelegatedTiActivity activityProvider,
             final TiViewProvider<V> viewProvider,
             final TiPresenterProvider<P> presenterProvider,
             final TiLoggingTagProvider logTag,

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/HostingActivity.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/HostingActivity.java
@@ -42,13 +42,8 @@ public class HostingActivity {
 
     public Activity getMockActivityInstance() {
         // always update with latest data
-        when(mActivityMock.isChangingConfigurations()).thenReturn(mIsChangingConfiguration);
         when(mActivityMock.isFinishing()).thenReturn(mIsFinishing);
         return mActivityMock;
-    }
-
-    public boolean isChangingConfiguration() {
-        return mIsChangingConfiguration;
     }
 
     public boolean isFinishing() {

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/HostingActivity.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/HostingActivity.java
@@ -31,8 +31,6 @@ public class HostingActivity {
 
     private final Activity mActivityMock;
 
-    private boolean mIsChangingConfiguration;
-
     private boolean mIsFinishing;
 
     public HostingActivity() {
@@ -48,10 +46,6 @@ public class HostingActivity {
 
     public boolean isFinishing() {
         return mIsFinishing;
-    }
-
-    public void setChangingConfiguration(final boolean changingConfiguration) {
-        mIsChangingConfiguration = changingConfiguration;
     }
 
     public void setFinishing(final boolean finishing) {

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/MultipleTiFragmentPresenterDestroyTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/MultipleTiFragmentPresenterDestroyTest.java
@@ -61,7 +61,6 @@ public class MultipleTiFragmentPresenterDestroyTest extends AbstractPresenterDes
         assertThat(mSavior.getPresenterCount()).isEqualTo(0);
 
         // When the Activity is changing its configuration.
-        hostingActivity.setChangingConfiguration(true);
 
         // Then nothing happens with the fragment, not managed anymore
         assertThat(fragment.getPresenter().isDestroyed()).isTrue();
@@ -103,7 +102,6 @@ public class MultipleTiFragmentPresenterDestroyTest extends AbstractPresenterDes
         assertThat(mSavior.getPresenterCount()).isEqualTo(0);
 
         // When the Activity is changing its configuration.
-        hostingActivity.setChangingConfiguration(true);
         fragment.onSaveInstanceState(mFragmentSavedState);
         fragment.onDestroy();
 
@@ -150,7 +148,6 @@ public class MultipleTiFragmentPresenterDestroyTest extends AbstractPresenterDes
         assertThat(mSavior.getPresenterCount()).isEqualTo(0);
 
         // When the Activity is changing its configuration.
-        hostingActivity.setChangingConfiguration(true);
 
         // Then nothing happens with the fragment, not managed anymore
         assertThat(fragment.getPresenter().isDestroyed()).isTrue();
@@ -195,7 +192,6 @@ public class MultipleTiFragmentPresenterDestroyTest extends AbstractPresenterDes
         assertThat(mSavior.getPresenterCount()).isEqualTo(1);
 
         // When the Activity is changing its configuration.
-        hostingActivity.setChangingConfiguration(true);
         mSavior.mActivityInstanceObserver.onActivitySaveInstanceState(
                 hostingActivity.getMockActivityInstance(), mActivitySavedState);
         fragment.onSaveInstanceState(mFragmentSavedState);
@@ -270,7 +266,6 @@ public class MultipleTiFragmentPresenterDestroyTest extends AbstractPresenterDes
         assertThat(mSavior.getPresenterCount()).isEqualTo(0);
 
         // When the Activity is changing its configuration.
-        hostingActivity.setChangingConfiguration(true);
         assertThat(mSavior.mActivityInstanceObserver).isNull();
         fragment.onSaveInstanceState(mFragmentSavedState);
         fragment.onDestroy();
@@ -330,7 +325,6 @@ public class MultipleTiFragmentPresenterDestroyTest extends AbstractPresenterDes
         assertThat(mSavior.getPresenterCount()).isEqualTo(1);
 
         // When the Activity is changing its configuration.
-        hostingActivity.setChangingConfiguration(true);
         mSavior.mActivityInstanceObserver.onActivitySaveInstanceState(
                 hostingActivity.getMockActivityInstance(), mActivitySavedState);
         fragment.onSaveInstanceState(mFragmentSavedState);

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities.java
@@ -96,7 +96,6 @@ public class MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities
         fragment.onDestroyView();
 
         // And when the Activity is changing its configuration.
-        hostingActivity.setChangingConfiguration(true);
         fragment.onSaveInstanceState(mFragmentSavedState);
         fragment.onDestroy();
 
@@ -140,7 +139,6 @@ public class MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities
         assertThat(mSavior.getPresenterCount()).isEqualTo(0);
 
         // When the Activity is changing its configuration.
-        hostingActivity.setChangingConfiguration(true);
 
         // Then nothing happens with the fragment, not managed anymore
         assertThat(fragment.getPresenter().isDestroyed()).isTrue();
@@ -182,7 +180,6 @@ public class MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities
         assertThat(mSavior.getPresenterCount()).isEqualTo(1);
 
         // When the Activity is changing its configuration.
-        hostingActivity.setChangingConfiguration(true);
         mSavior.mActivityInstanceObserver.onActivitySaveInstanceState(
                 hostingActivity.getMockActivityInstance(), mActivitySavedState);
         fragment.onSaveInstanceState(mFragmentSavedState);
@@ -221,67 +218,6 @@ public class MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities
     }
 
     @Test
-    public void activityChangingConfiguration_thenFinish_retainTrue_backstackTrue_dkATrue() {
-
-        final HostingActivity hostingActivity = new HostingActivity();
-
-        // Given a Presenter that uses a static savior to retain itself.
-        final TestPresenter presenter = new TestPresenter(new TiConfiguration.Builder()
-                .setRetainPresenterEnabled(true)
-                .build());
-
-        // And given a Fragment.
-        final TestTiFragment fragment = new TestTiFragment.Builder()
-                .setHostingActivity(hostingActivity)
-                .setSavior(mSavior)
-                .setPresenter(presenter)
-                .build();
-
-        // When the Fragment is added to the Activity.
-        fragment.setInBackstack(true);
-        fragment.onCreate(null);
-        fragment.setAdded(true);
-        fragment.onCreateView(mock(LayoutInflater.class), null, null);
-        fragment.onStart();
-
-        // And when the Fragment is replaced by another Fragment.
-        fragment.setAdded(false);
-        fragment.setRemoving(true);
-        fragment.onStop();
-        fragment.onDestroyView();
-
-        // Then the presenter is not destroyed and saved in the savior
-        assertThat(fragment.getPresenter().isDestroyed()).isFalse();
-        assertThat(mSavior.getPresenterCount()).isEqualTo(1);
-
-        // When the Activity is changing its configuration.
-        hostingActivity.setChangingConfiguration(true);
-        mSavior.mActivityInstanceObserver.onActivitySaveInstanceState(
-                hostingActivity.getMockActivityInstance(), mActivitySavedState);
-        fragment.onSaveInstanceState(mFragmentSavedState);
-        fragment.onDestroy();
-
-        // Then a new Activity is recreated.
-        final HostingActivity hostingActivity2 = new HostingActivity();
-        mSavior.mActivityInstanceObserver.onActivityCreated(
-                hostingActivity2.getMockActivityInstance(), mActivitySavedState);
-
-        // Then the Presenter is not destroyed and saved in the savior.
-        assertThat(fragment.getPresenter().isDestroyed()).isFalse();
-        assertThat(mSavior.getPresenterCount()).isEqualTo(1);
-
-        // When the Activity gets finished
-        hostingActivity2.setFinishing(true);
-        mSavior.mActivityInstanceObserver.onActivityDestroyed(
-                hostingActivity2.getMockActivityInstance());
-
-        // Then the same presenter is destroyed
-        assertThat(mSavior.getPresenterCount()).isEqualTo(0);
-        assertThat(presenter.isDestroyed()).isTrue();
-    }
-
-
-    @Test
     public void activityChangingConfiguration_thenFinish_retainFalse_backstackTrue_dkATrue() {
 
         final HostingActivity hostingActivity = new HostingActivity();
@@ -317,8 +253,6 @@ public class MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities
         // Then the presenter is not saved in the savior
         assertThat(mSavior.getPresenterCount()).isEqualTo(0);
 
-        // When the Activity is changing its configuration.
-        hostingActivity.setChangingConfiguration(true);
         assertThat(mSavior.mActivityInstanceObserver).isNull();
         fragment.onSaveInstanceState(mFragmentSavedState);
         fragment.onDestroy();
@@ -336,6 +270,64 @@ public class MultipleTiFragmentPresenterDestroyTestIgnoreDontKeepActivities
         assertThat(mSavior.mActivityInstanceObserver).isNull();
 
         // Then nothing happens, the presenter is already destroyed
+        assertThat(mSavior.getPresenterCount()).isEqualTo(0);
+        assertThat(presenter.isDestroyed()).isTrue();
+    }
+
+    @Test
+    public void activityChangingConfiguration_thenFinish_retainTrue_backstackTrue_dkATrue() {
+
+        final HostingActivity hostingActivity = new HostingActivity();
+
+        // Given a Presenter that uses a static savior to retain itself.
+        final TestPresenter presenter = new TestPresenter(new TiConfiguration.Builder()
+                .setRetainPresenterEnabled(true)
+                .build());
+
+        // And given a Fragment.
+        final TestTiFragment fragment = new TestTiFragment.Builder()
+                .setHostingActivity(hostingActivity)
+                .setSavior(mSavior)
+                .setPresenter(presenter)
+                .build();
+
+        // When the Fragment is added to the Activity.
+        fragment.setInBackstack(true);
+        fragment.onCreate(null);
+        fragment.setAdded(true);
+        fragment.onCreateView(mock(LayoutInflater.class), null, null);
+        fragment.onStart();
+
+        // And when the Fragment is replaced by another Fragment.
+        fragment.setAdded(false);
+        fragment.setRemoving(true);
+        fragment.onStop();
+        fragment.onDestroyView();
+
+        // Then the presenter is not destroyed and saved in the savior
+        assertThat(fragment.getPresenter().isDestroyed()).isFalse();
+        assertThat(mSavior.getPresenterCount()).isEqualTo(1);
+
+        mSavior.mActivityInstanceObserver.onActivitySaveInstanceState(
+                hostingActivity.getMockActivityInstance(), mActivitySavedState);
+        fragment.onSaveInstanceState(mFragmentSavedState);
+        fragment.onDestroy();
+
+        // Then a new Activity is recreated.
+        final HostingActivity hostingActivity2 = new HostingActivity();
+        mSavior.mActivityInstanceObserver.onActivityCreated(
+                hostingActivity2.getMockActivityInstance(), mActivitySavedState);
+
+        // Then the Presenter is not destroyed and saved in the savior.
+        assertThat(fragment.getPresenter().isDestroyed()).isFalse();
+        assertThat(mSavior.getPresenterCount()).isEqualTo(1);
+
+        // When the Activity gets finished
+        hostingActivity2.setFinishing(true);
+        mSavior.mActivityInstanceObserver.onActivityDestroyed(
+                hostingActivity2.getMockActivityInstance());
+
+        // Then the same presenter is destroyed
         assertThat(mSavior.getPresenterCount()).isEqualTo(0);
         assertThat(presenter.isDestroyed()).isTrue();
     }

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/PresenterSaviorTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/PresenterSaviorTest.java
@@ -273,7 +273,6 @@ public class PresenterSaviorTest {
         final String id = savior.save(presenter, hostingActivity.getMockActivityInstance());
 
         // Activity changes configuration
-        hostingActivity.isChangingConfiguration();
         savior.mActivityInstanceObserver.onActivitySaveInstanceState(
                 hostingActivity.getMockActivityInstance(), mSavedState);
         final String scopeId = fakeBundle.get(ActivityInstanceObserver.TI_ACTIVITY_ID_KEY);

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/PresenterSaviorTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/PresenterSaviorTest.java
@@ -239,7 +239,6 @@ public class PresenterSaviorTest {
         assertThat(savior.getPresenterCount()).isEqualTo(1);
         assertThat(id).isNotEmpty().isNotNull();
 
-        hostingActivity.setChangingConfiguration(true);
         savior.mActivityInstanceObserver
                 .onActivityDestroyed(hostingActivity.getMockActivityInstance());
 

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/SingleTiFragmentPresenterDestroyTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/SingleTiFragmentPresenterDestroyTest.java
@@ -61,7 +61,6 @@ public class SingleTiFragmentPresenterDestroyTest extends AbstractPresenterDestr
         assertThat(mSavior.mActivityInstanceObserver).isNull();
 
         // And when the Activity is changing its configuration.
-        hostingActivity.setChangingConfiguration(true);
         fragment.onSaveInstanceState(mFragmentSavedState);
         fragment.onStop();
         fragment.onDestroyView();
@@ -131,7 +130,6 @@ public class SingleTiFragmentPresenterDestroyTest extends AbstractPresenterDestr
         assertThat(mSavior.getPresenterCount()).isEqualTo(1);
 
         // And when the Activity is changing its configurations.
-        hostingActivity.setChangingConfiguration(true);
         mSavior.mActivityInstanceObserver.onActivitySaveInstanceState(
                 hostingActivity.getMockActivityInstance(), mActivitySavedState);
         fragment.onSaveInstanceState(mFragmentSavedState);

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/SingleTiFragmentPresenterDestroyTestIgnoreKeepDontKeepActivities.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/SingleTiFragmentPresenterDestroyTestIgnoreKeepDontKeepActivities.java
@@ -66,7 +66,6 @@ public class SingleTiFragmentPresenterDestroyTestIgnoreKeepDontKeepActivities
         assertThat(mSavior.mActivityInstanceObserver).isNull();
 
         // And when the Activity is changing its configuration.
-        hostingActivity.setChangingConfiguration(true);
         fragment.onSaveInstanceState(mFragmentSavedState);
         fragment.onStop();
         fragment.onDestroyView();
@@ -131,7 +130,6 @@ public class SingleTiFragmentPresenterDestroyTestIgnoreKeepDontKeepActivities
         assertThat(mSavior.getPresenterCount()).isEqualTo(1);
 
         // And when the Activity is changing its configuration.
-        hostingActivity.setChangingConfiguration(true);
         mSavior.mActivityInstanceObserver.onActivitySaveInstanceState(
                 hostingActivity.getMockActivityInstance(), mActivitySavedState);
         fragment.onSaveInstanceState(mFragmentSavedState);

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/TestTiActivity.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/TestTiActivity.java
@@ -119,17 +119,8 @@ public class TestTiActivity
     }
 
     @Override
-    public boolean isActivityChangingConfigurations() {
-        return mHostingActivity.isChangingConfiguration();
-    }
-
-    @Override
     public boolean isActivityFinishing() {
         return mHostingActivity.isFinishing();
-    }
-
-    public void onConfigurationChanged() {
-        mDelegate.onConfigurationChanged_afterSuper(mock(Configuration.class));
     }
 
     public void onCreate(final Bundle saveInstanceState) {

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/TestTiActivity.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/TestTiActivity.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.mock;
  * {@link TiActivityDelegate} for testing
  */
 public class TestTiActivity
-        implements DelegatedTiActivity<TiPresenter<TiView>>, TiViewProvider<TiView>,
+        implements DelegatedTiActivity, TiViewProvider<TiView>,
         PresenterAccessor<TiPresenter<TiView>, TiView> {
 
     public static final class Builder {

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/TestTiActivity.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/TestTiActivity.java
@@ -150,10 +150,6 @@ public class TestTiActivity
         return mock(TiView.class);
     }
 
-    public void setChangingConfiguration(final boolean changingConfiguration) {
-        mHostingActivity.setChangingConfiguration(changingConfiguration);
-    }
-
     public void setFinishing(final boolean finishing) {
         mHostingActivity.setFinishing(finishing);
     }

--- a/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/TiActivityPresenterDestroyTest.java
+++ b/thirtyinch/src/test/java/net/grandcentrix/thirtyinch/internal/TiActivityPresenterDestroyTest.java
@@ -47,7 +47,6 @@ public class TiActivityPresenterDestroyTest extends AbstractPresenterDestroyTest
 
         // When the Activity changes configurations
         activity.setFinishing(false);
-        activity.setChangingConfiguration(true);
         activity.onStop();
         assertThat(mSavior.mActivityInstanceObserver).isNull();
         activity.onSaveInstanceState(mActivitySavedState);
@@ -98,7 +97,6 @@ public class TiActivityPresenterDestroyTest extends AbstractPresenterDestroyTest
 
         // When the Activity changes configurations
         activity.setFinishing(false);
-        activity.setChangingConfiguration(true);
         activity.onStop();
         assertThat(mSavior.mActivityInstanceObserver).isNull();
         activity.onSaveInstanceState(mActivitySavedState);
@@ -149,7 +147,6 @@ public class TiActivityPresenterDestroyTest extends AbstractPresenterDestroyTest
 
         // When the Activity changes configurations
         activity.setFinishing(false);
-        activity.setChangingConfiguration(true);
         activity.onStop();
         mSavior.mActivityInstanceObserver.onActivitySaveInstanceState(
                 activity.getMockActivityInstance(), mActivitySavedState);
@@ -198,7 +195,6 @@ public class TiActivityPresenterDestroyTest extends AbstractPresenterDestroyTest
 
         // When the Activity changes configurations
         activity.setFinishing(false);
-        activity.setChangingConfiguration(true);
         activity.onStop();
         mSavior.mActivityInstanceObserver.onActivitySaveInstanceState(
                 activity.getMockActivityInstance(), mActivitySavedState);
@@ -247,7 +243,6 @@ public class TiActivityPresenterDestroyTest extends AbstractPresenterDestroyTest
 
         // When the Activity gets finished
         activity.setFinishing(true);
-        activity.setChangingConfiguration(false);
         activity.onStop();
         assertThat(mSavior.mActivityInstanceObserver).isNull();
         activity.onSaveInstanceState(mActivitySavedState);
@@ -281,7 +276,6 @@ public class TiActivityPresenterDestroyTest extends AbstractPresenterDestroyTest
 
         // When the Activity gets finished
         activity.setFinishing(true);
-        activity.setChangingConfiguration(false);
         activity.onStop();
         assertThat(mSavior.mActivityInstanceObserver).isNull();
         activity.onSaveInstanceState(mActivitySavedState);
@@ -318,7 +312,6 @@ public class TiActivityPresenterDestroyTest extends AbstractPresenterDestroyTest
 
         // When the Activity gets finished
         activity.setFinishing(true);
-        activity.setChangingConfiguration(false);
         activity.onStop();
         mSavior.mActivityInstanceObserver.onActivitySaveInstanceState(
                 activity.getMockActivityInstance(), mActivitySavedState);
@@ -353,7 +346,6 @@ public class TiActivityPresenterDestroyTest extends AbstractPresenterDestroyTest
 
         // When the Activity gets finished
         activity.setFinishing(true);
-        activity.setChangingConfiguration(false);
         activity.onStop();
         mSavior.mActivityInstanceObserver.onActivitySaveInstanceState(
                 activity.getMockActivityInstance(), mActivitySavedState);
@@ -388,7 +380,6 @@ public class TiActivityPresenterDestroyTest extends AbstractPresenterDestroyTest
 
         // When the Activity moves to background
         activity.setFinishing(false);
-        activity.setChangingConfiguration(false);
         activity.onStop();
         assertThat(mSavior.mActivityInstanceObserver).isNull();
 
@@ -423,7 +414,6 @@ public class TiActivityPresenterDestroyTest extends AbstractPresenterDestroyTest
 
         // When the Activity moves to background
         activity.setFinishing(false);
-        activity.setChangingConfiguration(false);
         activity.onStop();
         assertThat(mSavior.mActivityInstanceObserver).isNull();
         activity.onSaveInstanceState(mActivitySavedState);
@@ -475,7 +465,6 @@ public class TiActivityPresenterDestroyTest extends AbstractPresenterDestroyTest
 
         // When the Activity moves to background
         activity.setFinishing(false);
-        activity.setChangingConfiguration(false);
         activity.onStop();
         mSavior.mActivityInstanceObserver.onActivitySaveInstanceState(
                 activity.getMockActivityInstance(), mActivitySavedState);
@@ -511,7 +500,6 @@ public class TiActivityPresenterDestroyTest extends AbstractPresenterDestroyTest
 
         // When the Activity moves to background
         activity.setFinishing(false);
-        activity.setChangingConfiguration(false);
         activity.onStop();
         mSavior.mActivityInstanceObserver.onActivitySaveInstanceState(
                 activity.getMockActivityInstance(), mActivitySavedState);


### PR DESCRIPTION
This will declare `DelegatedTiActivity#isActivityChangingConfigurations` as deprecated. We don't need that call anymore. Our internal API have removed the call to it. 
Public API's are set to deprecated with a hint what to use now.

With that change I also removed the generic from the `DelegatedTiActivtiy`. It's not needed...