### PR TITLE
Fix crash when calling sendToView while the Presenter attaches the view

### DIFF
--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
@@ -89,6 +89,15 @@ public abstract class TiPresenter<V extends TiView> {
 
     private LinkedBlockingQueue<ViewAction<V>> mPostponedViewActions = new LinkedBlockingQueue<>();
 
+    /**
+     * view is attached and all {@link #mLifecycleObservers} have been notified about the attache
+     * event. The view is now in a "running" state
+     *
+     * This is a temporary field without public getter until the presenter state and notifications
+     * get completely refactored
+     */
+    private boolean mRunning = false;
+
     private State mState = State.INITIALIZED;
 
     /**
@@ -198,6 +207,10 @@ public abstract class TiPresenter<V extends TiView> {
         }
         moveToState(State.VIEW_ATTACHED, true);
 
+        // TODO refactor events and add a new state HERE when the view is attached and prepared by all observers.
+        // Calling this a "running" state for now, prevents executing postponed actions before this point
+        mRunning = true;
+
         sendPostponedActionsToView(view);
     }
 
@@ -269,6 +282,7 @@ public abstract class TiPresenter<V extends TiView> {
             TiLog.v(TAG, "not calling onDetachView(), not woken up");
             return;
         }
+        mRunning = false;
         moveToState(State.VIEW_DETACHED, false);
         mCalled = false;
         TiLog.v(TAG, "deprecated onSleep()");
@@ -386,6 +400,21 @@ public abstract class TiPresenter<V extends TiView> {
      */
     public void setUiThreadExecutor(@Nullable final Executor uiThreadExecutor) {
         mUiThreadExecutor = uiThreadExecutor;
+
+        if (uiThreadExecutor == null) {
+            return;
+        }
+
+        // execute pending actions when already in running state
+        final V view = getView();
+        if (view != null && mRunning) {
+            uiThreadExecutor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    sendPostponedActionsToView(view);
+                }
+            });
+        }
     }
 
     @Override
@@ -515,7 +544,7 @@ public abstract class TiPresenter<V extends TiView> {
      */
     protected void sendToView(final ViewAction<V> action) {
         final V view = getView();
-        if (view != null) {
+        if (view != null && mUiThreadExecutor != null) {
             runOnUiThread(new Runnable() {
                 @Override
                 public void run() {


### PR DESCRIPTION
@k0shk0sh discovered a one in a million crash in production

```
Fatal Exception: java.lang.IllegalStateException: no ui thread executor available
       at net.grandcentrix.thirtyinch.TiPresenter.runOnUiThread(TiPresenter.java:371)
       at net.grandcentrix.thirtyinch.TiPresenter.sendToView(TiPresenter.java:518)
       ...
```

It was possible to call `sendToView` when the `view` is set but a `uiThreadExecutor` was not.

```java
// attachView(view)
       ...
        mView = view;
        moveToState(State.VIEW_ATTACHED, false);
       ...
```

`sendToView` was called after `mView = view;` on a different Thread.

This fix checks both (`view` and `mUiThreadExecutor`) to be available before calling `runOnUiThread`.

Additionally `sendPostponedActionsToView` will now be called when setting a new  `uiThreadExecutor` in case a third party PresenterHost has to change the `uiThreadExecutor` while the `view` is attached or attaches it after `onAttachView(view)` for some reason