### PR TITLE
Let's detect Ti by AboutLibraries

### DIFF
--- a/thirtyinch/proguard-rules.txt
+++ b/thirtyinch/proguard-rules.txt
@@ -1,2 +1,8 @@
 # ThirtyInch
 -keep public class * implements net.grandcentrix.thirtyinch.distinctuntilchanged.DistinctComparator
+
+# Keep string ressources if we find a member with define_
+# This is needed for detection by AboutLibraries. See https://git.io/vQhQa
+-keepclasseswithmembers class **.R$string {
+    public static final int define_*;
+}

--- a/thirtyinch/src/main/res/values/library_thirtyinch_strings.xml
+++ b/thirtyinch/src/main/res/values/library_thirtyinch_strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="define_thirtyinch">year;owner</string>
+    <string name="library_thirtyinch_author">grandcentrix</string>
+    <string name="library_thirtyinch_authorWebsite">https://www.grandcentrix.net/</string>
+    <string name="library_thirtyinch_classPath">net.grandcentrix.thirtyinch.TiPresenter</string>
+    <string name="library_thirtyinch_libraryName">ThirtyInch</string>
+    <string name="library_thirtyinch_libraryDescription">A MVP library for Android favoring a stateful Presenter.</string>
+    <string name="library_thirtyinch_libraryVersion">0.8.0</string>
+    <string name="library_thirtyinch_libraryWebsite">https://github.com/grandcentrix/ThirtyInch</string>
+    <string name="library_thirtyinch_licenseId">apache_2_0</string>
+    <string name="library_thirtyinch_isOpenSource">true</string>
+    <string name="library_thirtyinch_repositoryLink">https://github.com/grandcentrix/ThirtyInch</string>
+    <!-- Custom variables section -->
+    <string name="library_thirtyinch_owner">grandcentrix</string>
+    <string name="library_thirtyinch_year">2016</string>
+</resources>


### PR DESCRIPTION
Since some apps (e.g. [FastHub](https://github.com/k0shk0sh/FastHub)) uses ThirtyInch along with [AboutLibraries](https://github.com/mikepenz/AboutLibraries) we should add the support for it.

This PR will fix it. If someone uses ThirtyInch as a library with AboutLibraries it will be automatically added to the AboutLibrary-Activity.

You can test it by checking our [this branch](https://github.com/StefMa/ThirtyInch/tree/test/about_libraries).

A gif in action:
![geist_1500457576288](https://user-images.githubusercontent.com/10229883/28361104-edc5a110-6c77-11e7-8d5e-edf06fe2f92e.gif)
