### PR TITLE
Move travis to docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   
 android:
   components:
-    - $(if [ $TEST_SUITE == "instrumentation" ]; then echo "tools,platform-tools,tools,build-tools-26.0.1,android-22,android-26,extra-google-google_play_services,extra-google-m2repository,extra-android-m2repository,addon-google_apis-google-24,sys-img-armeabi-v7a-android-22"; fi)
+    - $(if [ $TEST_SUITE == "instrumentation" ]; then ./.travisAndroidComponents.sh; fi)
 
 before_install:
   - if [ $TEST_SUITE == "unit" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,49 +1,42 @@
-language: android
-jdk:
-    - oraclejdk8
+sudo: required
 
+language: android
+jdk: oraclejdk8
+
+services:
+  - docker
+  
+env:
+ - TEST_SUITE=unit
+ - TEST_SUITE=instrumentation
+  
 android:
   components:
-    # Uncomment the lines below if you want to
-    # use the latest revision of Android SDK Tools
-    - tools
-    - platform-tools
-    - tools
+    - $(if [ $TEST_SUITE == "instrumentation" ]; then echo "tools,platform-tools,tools,build-tools-26.0.1,android-22,android-26,extra-google-google_play_services,extra-google-m2repository,extra-android-m2repository,addon-google_apis-google-24,sys-img-armeabi-v7a-android-22"; fi)
 
-    # The BuildTools version used by your project
-    - build-tools-26.0.1
-
-    # The SDK version used to compile your project
-    - android-22
-    - android-26
-
-    # Additional components
-    - extra-google-google_play_services
-    - extra-google-m2repository
-    - extra-android-m2repository
-    - addon-google_apis-google-24
-
-    # Specify at least one system image,
-    # if you need to run emulator(s) during your tests
-    - sys-img-armeabi-v7a-android-22
-
-
+before_install:
+  - if [ $TEST_SUITE == "unit" ]; then
+    docker pull stefma-docker-hub.bintray.io/android-build-env:0.1-alpha;
+    docker run -i -v $PWD:/project -t stefma-docker-hub.bintray.io/android-build-env:0.1-alpha /bin/bash -c "./gradlew build jacocoTestReport";
+    fi
+    
 before_script:
-
-  # First assemble the project before launching the emulator
-  - ./gradlew assemble
-
-  # List available emulators
-  - android list targets
-
   # Emulator Management: Create, Start and Wait
-  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
-  - emulator -avd test -no-skin -no-audio -no-window &
-  - android-wait-for-emulator
-  - adb shell input keyevent 82 &
+  - if [ $TEST_SUITE == "instrumentation" ]; then
+    ./gradlew assemble;
+    echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a;
+    emulator -avd test -no-skin -no-audio -no-window &
+    android-wait-for-emulator;
+    adb shell input keyevent 82 &
+    fi   
 
 script:
-  - ./gradlew build jacocoTestReport assembleAndroidTest connectedCheck
+  - if [ $TEST_SUITE == "instrumentation" ]; then 
+    ./gradlew assembleAndroidTest connectedCheck;
+    fi
+  - if [ $TEST_SUITE == "unit" ]; then
+    echo "Everything is done already in the before_install docker...";
+    fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ android:
 before_install:
   - if [ $TEST_SUITE == "unit" ]; then
     docker pull stefma-docker-hub.bintray.io/android-build-env:0.1-alpha;
-    docker run -i -v $PWD:/project -t stefma-docker-hub.bintray.io/android-build-env:0.1-alpha /bin/bash -c "./gradlew build jacocoTestReport";
     fi
     
 before_script:
@@ -35,7 +34,7 @@ script:
     ./gradlew assembleAndroidTest connectedCheck;
     fi
   - if [ $TEST_SUITE == "unit" ]; then
-    echo "Everything is done already in the before_install docker...";
+    docker run -i -v $PWD:/project -t stefma-docker-hub.bintray.io/android-build-env:0.1-alpha /bin/bash -c "./gradlew build jacocoTestReport";
     fi
 
 after_success:

--- a/.travisAndroidComponents.sh
+++ b/.travisAndroidComponents.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Read the BUILD_TOOL_VERSION and COMPILE_SDK_VERSION
+BUILD_TOOLS_VERSION=$(cat build.gradle | grep "BUILD_TOOLS_VERSION*" | sed -e "s/^.*'\(.*\)'/\1/")
+COMPILE_SDK_VERSION=$(cat build.gradle | grep "COMPILE_SDK_VERSION*" | sed -e "s/^.*= \(.*\)$/\1/")
+
+# Echo every componnent we need to install and replace the BUILD_TOOLS_VERSION and COMPILE_SDK_VERSION
+echo "tools,platform-tools,tools,build-tools-$BUILD_TOOLS_VERSION,android-22,android-$COMPILE_SDK_VERSION,extra-google-google_play_services,extra-google-m2repository,extra-android-m2repository,addon-google_apis-google-24,sys-img-armeabi-v7a-android-22"


### PR DESCRIPTION
Based on #115 

* Do two build environments: unit and instrumentation (run in parallel) 
* Moved unit test to docker (because of the andoird images you can't really start a emulator in docker)

_**Benefits of using docker:**_
* The docker image contains only the "sdkamanger". The sdkmanager install every build-tools or android images if they needed automatically. We don't need to update the travis.yml anymore \o\
* We can trust the docker. If the underlined host (travis <-> trusty, zenty) changed, everything just works as before. As long as we can run docker in that environment.

_**Benefits of the new travisscript:**_
* It parses automatically the BUILD_TOOLS_VERSION and the SDK_VERSION from the build.gradle file and put it into the the travis android components. We don't need to update the travis.yml anymore /o/

_**Do we have speed benefits?**_
* Unfortunately not really. Because travis is very slow with starting a emulator and stuff it won't decrease the build time. Maybe 10 seconds or so because travis don't run the unit tests anymore :)

What do test:
* If codecov works as aspected -> **Checked ✅ works**