### PR TITLE
Add Javadoc for TiPresenter.test() method

### DIFF
--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/TiPresenter.java
@@ -386,6 +386,51 @@ public abstract class TiPresenter<V extends TiView> {
         mUiThreadExecutor = uiThreadExecutor;
     }
 
+    /**
+     * Creates {@link TiTestPresenter} that simplifies testing by calling the presenter lifecycle
+     * methods automatically in the correct order. It also sets the ui thread Executors which allows
+     * the usage of {@link TiPresenter#sendToView(ViewAction)} in unit test.
+     * <code>
+     * <pre>
+     *    &#64;Test
+     *    public void testLoadData() throws Exception {
+     *        final LoginPresenter loginPresenter = new LoginPresenter();
+     *        final TiTestPresenter<LoginView> testPresenter = loginPresenter.test();
+     *        final LoginView view = testPresenter.attachView(mock(LoginView.class));
+     *
+     *        loginPresenter.onSubmitClicked();
+     *        verify(view).showError("No username entered");
+     *    }
+     *
+     *    public class LoginPresenter extends TiPresenter<LoginView> {
+     *
+     *        public void onSubmitClicked() {
+     *            sendToView(new ViewAction<LoginView>() {
+     *                &#64;Override
+     *                public void call(final LoginView view) {
+     *                    view.showError("No username entered");
+     *                }
+     *            });
+     *        }
+     *    }
+     *
+     *    public interface LoginView extends TiView {
+     *        void showError(String msg);
+     *    }
+     * </pre>
+     * </code>
+     *
+     * <p>
+     * The problem is that {@link TiPresenter#sendToView(ViewAction)} needs a ui executor thread.
+     * Unfortunately a ui executor thread isn't available in unit test. Instead a mock implementation
+     * is provided which executes the actions immediately on the testing thread.
+     * </p>
+     * <p>
+     * This {@link TiTestPresenter} holds the {@link TiPresenter} under test.
+     * </p>
+     *
+     * @return instance of {@link TiTestPresenter}
+     */
     public TiTestPresenter<V> test() {
         return new TiTestPresenter<>(this);
     }


### PR DESCRIPTION
I would like to resolve #124 and add missed Javadoc for TiPresenter.test() method.