### PR TITLE
Update to gradle plugin 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ android:
     - tools
 
     # The BuildTools version used by your project
-    - build-tools-26.0.1
+    - build-tools-26.0.2
 
     # The SDK version used to compile your project
     - android-22

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.1'
     }
 }
@@ -29,7 +30,7 @@ ext {
     TARGET_SDK_VERSION = 26
     COMPILE_SDK_VERSION = 26
     // If you change the build tools version don't forgot to update .travis.yml
-    BUILD_TOOLS_VERSION = '26.0.1'
+    BUILD_TOOLS_VERSION = '26.0.2'
 
     supportLibraryVersion = '26.0.0'
     // compositeAndroidVersion should be always the same version as the supportLib version

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath "org.jacoco:org.jacoco.core:0.7.9"
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.1'
     }
 }

--- a/plugin-test/build.gradle
+++ b/plugin-test/build.gradle
@@ -23,14 +23,14 @@ android {
 }
 
 dependencies {
-    compile project(':thirtyinch-plugin')
+    implementation project(':thirtyinch-plugin')
 
-    compile "com.android.support:appcompat-v7:$supportLibraryVersion"
-    compile "com.pascalwelsch.compositeandroid:activity:$supportLibraryVersion"
-    compile "com.pascalwelsch.compositeandroid:fragment:$supportLibraryVersion"
+    implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
+    implementation "com.pascalwelsch.compositeandroid:activity:$supportLibraryVersion"
+    implementation "com.pascalwelsch.compositeandroid:fragment:$supportLibraryVersion"
 
-    androidTestCompile "com.android.support:support-annotations:$supportLibraryVersion"
-    androidTestCompile "com.android.support.test:runner:$supportTestVersion";
-    androidTestCompile "com.android.support.test:rules:$supportTestVersion";
-    androidTestCompile "com.android.support.test.espresso:espresso-core:$espressoVersion";
+    androidTestImplementation "com.android.support:support-annotations:$supportLibraryVersion"
+    androidTestImplementation "com.android.support.test:runner:$supportTestVersion";
+    androidTestImplementation "com.android.support.test:rules:$supportTestVersion";
+    androidTestImplementation "com.android.support.test.espresso:espresso-core:$espressoVersion";
 }

--- a/plugin-test/build.gradle
+++ b/plugin-test/build.gradle
@@ -24,6 +24,7 @@ android {
 
 dependencies {
     implementation project(':thirtyinch-plugin')
+    implementation project(':thirtyinch')
 
     implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
     implementation "com.pascalwelsch.compositeandroid:activity:$supportLibraryVersion"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-    id "me.tatarka.retrolambda" version "3.5.0"
-}
-
 apply plugin: 'com.android.application'
 
 android {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -44,12 +44,12 @@ android {
 }
 
 dependencies {
-    compile "com.android.support:appcompat-v7:$supportLibraryVersion"
-    compile 'com.jakewharton.rxbinding:rxbinding:1.0.1'
+    implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
+    implementation 'com.jakewharton.rxbinding:rxbinding:1.0.1'
 
+    implementation project(':thirtyinch')
+    implementation project(':thirtyinch-rx')
+    implementation project(':thirtyinch-logginginterceptor')
 
-    compile project(':thirtyinch')
-    compile project(':thirtyinch-rx')
-    compile project(':thirtyinch-logginginterceptor')
-    testCompile "junit:junit:$junitVersion"
+    testImplementation "junit:junit:$junitVersion"
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -22,6 +22,9 @@ android {
             // https://developer.android.com/studio/build/shrink-code.html#gradle-shrinker
             useProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+
+            // output coverage with ./gradlew clean build createDebugCoverageReport
+            testCoverageEnabled true
         }
         release {
             // use real proguard for release builds, not the build in shrinker which doesn't support obfuscation

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -22,9 +22,6 @@ android {
             // https://developer.android.com/studio/build/shrink-code.html#gradle-shrinker
             useProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-
-            // output coverage with ./gradlew clean build createDebugCoverageReport
-            testCoverageEnabled true
         }
         release {
             // use real proguard for release builds, not the build in shrinker which doesn't support obfuscation

--- a/sample/proguard-rules.pro
+++ b/sample/proguard-rules.pro
@@ -15,3 +15,4 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+-dontwarn org.jacoco.agent**

--- a/thirtyinch-logginginterceptor/build.gradle
+++ b/thirtyinch-logginginterceptor/build.gradle
@@ -36,12 +36,12 @@ android {
 }
 
 dependencies {
-    compile project(':thirtyinch')
-    provided "com.android.support:support-annotations:$supportLibraryVersion"
+    implementation project(':thirtyinch')
+    compileOnly "com.android.support:support-annotations:$supportLibraryVersion"
 
-    testCompile "junit:junit:$junitVersion"
-    testCompile "org.mockito:mockito-core:$mockitoVersion"
-    testCompile "org.assertj:assertj-core:$assertjVersion"
+    testImplementation "junit:junit:$junitVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation "org.assertj:assertj-core:$assertjVersion"
 }
 
 publish {

--- a/thirtyinch-plugin/build.gradle
+++ b/thirtyinch-plugin/build.gradle
@@ -36,9 +36,9 @@ android {
 }
 
 dependencies {
-    compile project(':thirtyinch')
-    provided "com.pascalwelsch.compositeandroid:activity:$compositeAndroidVersion"
-    provided "com.pascalwelsch.compositeandroid:fragment:$compositeAndroidVersion"
+    implementation project(':thirtyinch')
+    compileOnly "com.pascalwelsch.compositeandroid:activity:$compositeAndroidVersion"
+    compileOnly "com.pascalwelsch.compositeandroid:fragment:$compositeAndroidVersion"
 }
 
 publish {

--- a/thirtyinch-rx/build.gradle
+++ b/thirtyinch-rx/build.gradle
@@ -36,14 +36,14 @@ android {
 }
 
 dependencies {
-    compile project(':thirtyinch')
-    compile 'io.reactivex:rxjava:1.3.2'
-    compile 'com.artemzin.rxjava:proguard-rules:1.2.7.0'
-    provided "com.android.support:support-annotations:$supportLibraryVersion"
+    implementation project(':thirtyinch')
+    implementation 'io.reactivex:rxjava:1.3.2'
+    implementation 'com.artemzin.rxjava:proguard-rules:1.2.7.0'
+    compileOnly "com.android.support:support-annotations:$supportLibraryVersion"
 
-    testCompile "junit:junit:$junitVersion"
-    testCompile "org.mockito:mockito-core:$mockitoVersion"
-    testCompile "org.assertj:assertj-core:$assertjVersion"
+    testImplementation "junit:junit:$junitVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation "org.assertj:assertj-core:$assertjVersion"
 }
 
 publish {

--- a/thirtyinch-rx/build.gradle
+++ b/thirtyinch-rx/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation 'com.artemzin.rxjava:proguard-rules:1.2.7.0'
     compileOnly "com.android.support:support-annotations:$supportLibraryVersion"
 
+    testCompileOnly "com.android.support:support-annotations:$supportLibraryVersion"
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.assertj:assertj-core:$assertjVersion"

--- a/thirtyinch-rx2/build.gradle
+++ b/thirtyinch-rx2/build.gradle
@@ -36,13 +36,13 @@ android {
 }
 
 dependencies {
-    compile project(':thirtyinch')
-    compile 'io.reactivex.rxjava2:rxjava:2.1.4'
-    provided "com.android.support:support-annotations:$supportLibraryVersion"
+    implementation project(':thirtyinch')
+    implementation 'io.reactivex.rxjava2:rxjava:2.1.4'
+    compileOnly "com.android.support:support-annotations:$supportLibraryVersion"
 
-    testCompile "junit:junit:$junitVersion"
-    testCompile "org.mockito:mockito-core:$mockitoVersion"
-    testCompile "org.assertj:assertj-core:$assertjVersion"
+    testImplementation "junit:junit:$junitVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation "org.assertj:assertj-core:$assertjVersion"
 }
 
 publish {

--- a/thirtyinch-test/build.gradle
+++ b/thirtyinch-test/build.gradle
@@ -36,10 +36,10 @@ android {
 }
 
 dependencies {
-    compile project(':thirtyinch')
+    implementation project(':thirtyinch')
 
-    testCompile "junit:junit:$junitVersion"
-    testCompile "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation "junit:junit:$junitVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
 }
 
 publish {

--- a/thirtyinch/build.gradle
+++ b/thirtyinch/build.gradle
@@ -45,15 +45,15 @@ android {
 }
 
 dependencies {
-    provided "com.android.support:appcompat-v7:$supportLibraryVersion"
+    compileOnly "com.android.support:appcompat-v7:$supportLibraryVersion"
 
-    testCompile "junit:junit:$junitVersion"
-    testCompile "org.mockito:mockito-core:$mockitoVersion"
-    testCompile "org.assertj:assertj-core:$assertjVersion"
+    testImplementation "junit:junit:$junitVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation "org.assertj:assertj-core:$assertjVersion"
 
-    androidTestCompile "com.android.support.test:runner:$supportTestVersion"
-    androidTestCompile "org.mockito:mockito-core:$mockitoVersion"
-    androidTestCompile "org.assertj:assertj-core:$assertjVersion"
+    androidTestImplementation "com.android.support.test:runner:$supportTestVersion"
+    androidTestImplementation  "org.mockito:mockito-core:$mockitoVersion"
+    androidTestImplementation  "org.assertj:assertj-core:$assertjVersion"
 }
 
 publish {

--- a/thirtyinch/build.gradle
+++ b/thirtyinch/build.gradle
@@ -47,13 +47,14 @@ android {
 dependencies {
     compileOnly "com.android.support:appcompat-v7:$supportLibraryVersion"
 
+    testCompileOnly "com.android.support:support-annotations:$supportLibraryVersion"
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.assertj:assertj-core:$assertjVersion"
 
     androidTestImplementation "com.android.support.test:runner:$supportTestVersion"
-    androidTestImplementation  "org.mockito:mockito-core:$mockitoVersion"
-    androidTestImplementation  "org.assertj:assertj-core:$assertjVersion"
+    androidTestImplementation "org.mockito:mockito-core:$mockitoVersion"
+    androidTestImplementation "org.assertj:assertj-core:$assertjVersion"
 }
 
 publish {


### PR DESCRIPTION
With that change we can think about our dependencies again.

Do we want to "bundle" the dependencies with our libraries or not?
Which means, do we want to use `api` or `implementation`?
If we decided we use `implementation` we can also think about to use `compileOnly` for "all", right?
Since we don't really need a special version or something. Our implementations are very "basic" and I think all future releases of our dependencies will support our implementation...

What do you think?

> **Note*:* While upgrading I had some issues with jacoco. So i declared the jacoco version and added the test coverage in the sample. [jacoco closure is depcreated ](https://google.github.io/android-gradle-dsl/current/com.android.build.gradle.BaseExtension.html#com.android.build.gradle.BaseExtension:jacoco(org.gradle.api.Action)). We have to add it to the classpath...