### PR TITLE
Move bintrayRelease 'setup' into own gradle file

### DIFF
--- a/gradle/bintrayRelease.gradle
+++ b/gradle/bintrayRelease.gradle
@@ -2,8 +2,8 @@ class MissingConfigurePublishException extends GradleException {
 
     MissingConfigurePublishException(String extraName) {
         super("Extra '$extraName' missing. " +
-                "Please provide with 'ext.set('$extraName', { ['artifactId': 'artifactId', desc: 'description'] })'" +
-                " (while 'desc' is optional)!")
+                "Please provide with 'ext.set('$extraName', { ['artifactId': 'artifactId', desc: 'description'] })' " +
+                "(while 'desc' is optional)!")
     }
 
 }
@@ -21,9 +21,7 @@ apply plugin: com.novoda.gradle.release.ReleasePlugin
 
 Closure configurePublish = ext.has('configurePublish') ? ext.get('configurePublish') : {}
 def config = configurePublish()
-if (config == null) {
-    throw new MissingConfigurePublishException('configurePublish')
-}
+if (config == null) throw new MissingConfigurePublishException('configurePublish')
 
 publish {
     userOrg = 'grandcentrix'

--- a/gradle/bintrayRelease.gradle
+++ b/gradle/bintrayRelease.gradle
@@ -1,0 +1,35 @@
+class MissingExtraException extends GradleException {
+
+    MissingExtraException(String extraName) {
+        super("Extra '$extraName' missing. Please provide with 'ext.set($extraName, value)'!")
+    }
+
+}
+
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath "com.novoda:bintray-release:$bintrayVersion"
+    }
+}
+
+apply plugin: com.novoda.gradle.release.ReleasePlugin
+
+String maybeArtifactId = ext.has("artifactId") ? ext.get("artifactId") : ""
+if (maybeArtifactId.isEmpty()) {
+    throw new MissingExtraException("artifactId")
+}
+
+String maybeDesc = ext.has("desc") ? ext.get("desc") : null
+
+publish {
+    userOrg = 'grandcentrix'
+    groupId = 'net.grandcentrix.thirtyinch'
+    publishVersion = VERSION_NAME
+    artifactId = "$maybeArtifactId"
+    uploadName = 'ThirtyInch'
+    desc = "$maybeDesc"
+    website = 'https://github.com/grandcentrix/ThirtyInch'
+}

--- a/gradle/bintrayRelease.gradle
+++ b/gradle/bintrayRelease.gradle
@@ -1,7 +1,9 @@
-class MissingExtraException extends GradleException {
+class MissingConfigurePublishException extends GradleException {
 
-    MissingExtraException(String extraName) {
-        super("Extra '$extraName' missing. Please provide with 'ext.set($extraName, value)'!")
+    MissingConfigurePublishException(String extraName) {
+        super("Extra '$extraName' missing. " +
+                "Please provide with 'ext.set('$extraName', { ['artifactId': 'artifactId', desc: 'description'] })'" +
+                " (while 'desc' is optional)!")
     }
 
 }
@@ -17,19 +19,18 @@ buildscript {
 
 apply plugin: com.novoda.gradle.release.ReleasePlugin
 
-String maybeArtifactId = ext.has("artifactId") ? ext.get("artifactId") : ""
-if (maybeArtifactId.isEmpty()) {
-    throw new MissingExtraException("artifactId")
+Closure configurePublish = ext.has('configurePublish') ? ext.get('configurePublish') : {}
+def config = configurePublish()
+if (config == null) {
+    throw new MissingConfigurePublishException('configurePublish')
 }
-
-String maybeDesc = ext.has("desc") ? ext.get("desc") : null
 
 publish {
     userOrg = 'grandcentrix'
     groupId = 'net.grandcentrix.thirtyinch'
     publishVersion = VERSION_NAME
-    artifactId = "$maybeArtifactId"
+    artifactId = config['artifactId']
     uploadName = 'ThirtyInch'
-    desc = "$maybeDesc"
+    desc = config['desc']
     website = 'https://github.com/grandcentrix/ThirtyInch'
 }

--- a/thirtyinch-logginginterceptor/build.gradle
+++ b/thirtyinch-logginginterceptor/build.gradle
@@ -32,5 +32,5 @@ dependencies {
 }
 
 // For uploading to bintray
-ext.set("artifactId", "thirtyinch-logginginterceptor")
+ext.set('configurePublish', { [artifactId: 'thirtyinch-logginginterceptor'] })
 apply from: '../gradle/bintrayRelease.gradle'

--- a/thirtyinch-logginginterceptor/build.gradle
+++ b/thirtyinch-logginginterceptor/build.gradle
@@ -1,14 +1,4 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath "com.novoda:bintray-release:$bintrayVersion"
-    }
-}
-
 apply plugin: 'com.android.library'
-apply plugin: 'bintray-release'
 
 android {
     compileSdkVersion COMPILE_SDK_VERSION
@@ -41,11 +31,6 @@ dependencies {
     testImplementation "org.assertj:assertj-core:$assertjVersion"
 }
 
-publish {
-    userOrg = 'grandcentrix'
-    groupId = 'net.grandcentrix.thirtyinch'
-    artifactId = 'thirtyinch-logginginterceptor'
-    uploadName = 'ThirtyInch'
-    publishVersion = VERSION_NAME
-    website = 'https://github.com/grandcentrix/ThirtyInch'
-}
+// For uploading to bintray
+ext.set("artifactId", "thirtyinch-logginginterceptor")
+apply from: '../gradle/bintrayRelease.gradle'

--- a/thirtyinch-plugin/build.gradle
+++ b/thirtyinch-plugin/build.gradle
@@ -1,14 +1,4 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath "com.novoda:bintray-release:$bintrayVersion"
-    }
-}
-
 apply plugin: 'com.android.library'
-apply plugin: 'bintray-release'
 
 android {
     compileSdkVersion COMPILE_SDK_VERSION
@@ -38,11 +28,6 @@ dependencies {
     compileOnly "com.pascalwelsch.compositeandroid:fragment:$compositeAndroidVersion"
 }
 
-publish {
-    userOrg = 'grandcentrix'
-    groupId = 'net.grandcentrix.thirtyinch'
-    artifactId = 'thirtyinch-plugin'
-    uploadName = 'ThirtyInch'
-    publishVersion = VERSION_NAME
-    website = 'https://github.com/grandcentrix/ThirtyInch'
-}
+// For uploading to bintray
+ext.set("artifactId", "thirtyinch-plugin")
+apply from: '../gradle/bintrayRelease.gradle'

--- a/thirtyinch-plugin/build.gradle
+++ b/thirtyinch-plugin/build.gradle
@@ -29,5 +29,5 @@ dependencies {
 }
 
 // For uploading to bintray
-ext.set("artifactId", "thirtyinch-plugin")
+ext.set('configurePublish', { ['artifactId': 'thirtyinch-plugin'] })
 apply from: '../gradle/bintrayRelease.gradle'

--- a/thirtyinch-rx/build.gradle
+++ b/thirtyinch-rx/build.gradle
@@ -35,5 +35,5 @@ dependencies {
 }
 
 // For uploading to bintray
-ext.set("artifactId", "thirtyinch-rx")
+ext.set('configurePublish', { ['artifactId': 'thirtyinch-rx'] })
 apply from: '../gradle/bintrayRelease.gradle'

--- a/thirtyinch-rx/build.gradle
+++ b/thirtyinch-rx/build.gradle
@@ -1,14 +1,4 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath "com.novoda:bintray-release:$bintrayVersion"
-    }
-}
-
 apply plugin: 'com.android.library'
-apply plugin: 'bintray-release'
 
 android {
     compileSdkVersion COMPILE_SDK_VERSION
@@ -44,11 +34,6 @@ dependencies {
     testImplementation "org.assertj:assertj-core:$assertjVersion"
 }
 
-publish {
-    userOrg = 'grandcentrix'
-    groupId = 'net.grandcentrix.thirtyinch'
-    artifactId = 'thirtyinch-rx'
-    uploadName = 'ThirtyInch'
-    publishVersion = VERSION_NAME
-    website = 'https://github.com/grandcentrix/ThirtyInch'
-}
+// For uploading to bintray
+ext.set("artifactId", "thirtyinch-rx")
+apply from: '../gradle/bintrayRelease.gradle'

--- a/thirtyinch-rx2/build.gradle
+++ b/thirtyinch-rx2/build.gradle
@@ -33,5 +33,5 @@ dependencies {
 }
 
 // For uploading to bintray
-ext.set("artifactId", "thirtyinch-rx2")
+ext.set('configurePublish', { ['artifactId': 'thirtyinch-rx2'] })
 apply from: '../gradle/bintrayRelease.gradle'

--- a/thirtyinch-rx2/build.gradle
+++ b/thirtyinch-rx2/build.gradle
@@ -1,14 +1,4 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath "com.novoda:bintray-release:$bintrayVersion"
-    }
-}
-
 apply plugin: 'com.android.library'
-apply plugin: 'bintray-release'
 
 android {
     compileSdkVersion COMPILE_SDK_VERSION
@@ -42,11 +32,6 @@ dependencies {
     testImplementation "org.assertj:assertj-core:$assertjVersion"
 }
 
-publish {
-    userOrg = 'grandcentrix'
-    groupId = 'net.grandcentrix.thirtyinch'
-    artifactId = 'thirtyinch-rx2'
-    uploadName = 'ThirtyInch'
-    publishVersion = VERSION_NAME
-    website = 'https://github.com/grandcentrix/ThirtyInch'
-}
+// For uploading to bintray
+ext.set("artifactId", "thirtyinch-rx2")
+apply from: '../gradle/bintrayRelease.gradle'

--- a/thirtyinch-test/build.gradle
+++ b/thirtyinch-test/build.gradle
@@ -30,5 +30,5 @@ dependencies {
 }
 
 // For uploading to bintray
-ext.set("artifactId", "thirtyinch-test")
+ext.set('configurePublish', { ['artifactId': 'thirtyinch-test'] })
 apply from: '../gradle/bintrayRelease.gradle'

--- a/thirtyinch-test/build.gradle
+++ b/thirtyinch-test/build.gradle
@@ -1,14 +1,4 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath "com.novoda:bintray-release:$bintrayVersion"
-    }
-}
-
 apply plugin: 'com.android.library'
-apply plugin: 'bintray-release'
 
 android {
     compileSdkVersion COMPILE_SDK_VERSION
@@ -39,11 +29,6 @@ dependencies {
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
 }
 
-publish {
-    userOrg = 'grandcentrix'
-    groupId = 'net.grandcentrix.thirtyinch'
-    artifactId = 'thirtyinch-test'
-    uploadName = 'ThirtyInch'
-    publishVersion = VERSION_NAME
-    website = 'https://github.com/grandcentrix/ThirtyInch'
-}
+// For uploading to bintray
+ext.set("artifactId", "thirtyinch-test")
+apply from: '../gradle/bintrayRelease.gradle'

--- a/thirtyinch/build.gradle
+++ b/thirtyinch/build.gradle
@@ -45,6 +45,5 @@ dependencies {
 }
 
 // For uploading to bintray
-ext.set("artifactId", "thirtyinch")
-ext.set("desc", "a Model View Presenter library for Android")
+ext.set('configurePublish', { [artifactId: 'thirtyinch', desc: 'a Model View Presenter library for Android'] })
 apply from: '../gradle/bintrayRelease.gradle'

--- a/thirtyinch/build.gradle
+++ b/thirtyinch/build.gradle
@@ -1,14 +1,4 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath "com.novoda:bintray-release:$bintrayVersion"
-    }
-}
-
 apply plugin: 'com.android.library'
-apply plugin: 'bintray-release'
 
 android {
     compileSdkVersion COMPILE_SDK_VERSION
@@ -54,12 +44,7 @@ dependencies {
     androidTestImplementation "org.assertj:assertj-core:$assertjVersion"
 }
 
-publish {
-    userOrg = 'grandcentrix'
-    groupId = 'net.grandcentrix.thirtyinch'
-    publishVersion = VERSION_NAME
-    artifactId = 'thirtyinch'
-    uploadName = 'ThirtyInch'
-    description = 'a Model View Presenter library for Android'
-    website = 'https://github.com/grandcentrix/ThirtyInch'
-}
+// For uploading to bintray
+ext.set("artifactId", "thirtyinch")
+ext.set("desc", "a Model View Presenter library for Android")
+apply from: '../gradle/bintrayRelease.gradle'


### PR DESCRIPTION
Just a little bit clean up.
I've extracted the bintrayRelease "setup" into its own gradle file.

After changing it I've tested it and uploaded it here https://dl.bintray.com/stefma/maven/net/grandcentrix/thirtyinch/
The `0.8.6-cool/` version is the uploaded one..
Seems to working 👍 😄 