### PR TITLE
Allow usage with AndroidX

### DIFF
--- a/thirtyinch/src/main/java/android/support/v4/app/BackstackReader.java
+++ b/thirtyinch/src/main/java/android/support/v4/app/BackstackReader.java
@@ -1,5 +1,8 @@
 package android.support.v4.app;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
 /**
  * Reads package private information about the {@link FragmentManager} backstack
  *
@@ -16,6 +19,20 @@ public class BackstackReader {
      * stack)
      */
     public static boolean isInBackStack(final Fragment fragment) {
-        return fragment.isInBackStack();
+        try {
+            return fragment.isInBackStack();
+        } catch (IllegalAccessError e) {
+            return isInBackStackAndroidX(fragment);
+        }
+    }
+
+    /**
+     * Hacky workaround because Fragment#isInBackStack is inaccessible with AndroidX
+     */
+    private static boolean isInBackStackAndroidX(final Fragment fragment) {
+        final StringWriter writer = new StringWriter();
+        fragment.dump("", null, new PrintWriter(writer), null);
+        final String dump = writer.toString();
+        return !dump.contains("mBackStackNesting=0");
     }
 }


### PR DESCRIPTION
AndroidX doesn’t allow calling of package private methods, like Fragment#isInBackstack. As a temporary workaround we can get the same information via the public dump() method.

The performance is fine and in my test scenarios always below <2ms.

fixes #149

### How to test

Testing is harder this time. 
1. I released this PR to `mavenLocal()`
2. I cloned Ti again, migrated the `sample` to AndroidX with Android Studio 3.2 beta4, disabled all other modules and included the new dependencies. (I pushed it [here](https://github.com/passsy/ThirtyInch/tree/feature/android_x_sample))

Converting Ti completely to AndroidX is no alternative. We want to test with `android.enableJetifier`.