### PR TITLE
Update bintrayrelease and fix CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-![License](https://img.shields.io/badge/license-Apache%202-green.svg?style=flat) [![Gitter](https://badges.gitter.im/ThirtyInch/gitter.svg)](https://gitter.im/ThirtyInch/Lobby)
+[![Build Status](https://travis-ci.org/grandcentrix/ThirtyInch.svg?branch=master)](https://travis-ci.org/grandcentrix/ThirtyInch)
+![License](https://img.shields.io/badge/license-Apache%202-green.svg?style=flat) 
+[![Gitter](https://badges.gitter.im/ThirtyInch/gitter.svg)](https://gitter.im/ThirtyInch/Lobby)
 # ThirtyInch - a MVP library for Android
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@
 buildscript {
     ext.kotlin_version = "1.2.51"
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath "com.android.tools.build:gradle:3.1.3" // if you update this, also update the lintVersion below
@@ -18,8 +18,8 @@ apply plugin: 'com.vanniktech.android.junit.jacoco'
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     tasks.withType(Javadoc) {
         options.addStringOption('Xdoclint:none', '-quiet')

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         classpath "com.android.tools.build:gradle:3.1.3" // if you update this, also update the lintVersion below
         classpath "com.vanniktech:gradle-android-junit-jacoco-plugin:0.10.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'guru.stefma.bintrayrelease:bintrayrelease:1.1.0'
+        classpath 'guru.stefma.bintrayrelease:bintrayrelease:1.1.1'
     }
 }
 


### PR DESCRIPTION
The old one had an issue which can't parse the properties correctly.

beside of this it will fix our CI.
See https://github.com/grandcentrix/ThirtyInch/pull/164/commits/51d02ad5eef4876fc9fc5f1717d1fbb3fb998e79