### PR TITLE
Update Rx ProGuard Rules

### DIFF
--- a/thirtyinch-rx/build.gradle
+++ b/thirtyinch-rx/build.gradle
@@ -25,7 +25,7 @@ android {
 dependencies {
     implementation project(':thirtyinch')
     api 'io.reactivex:rxjava:1.3.2'
-    implementation 'com.artemzin.rxjava:proguard-rules:1.2.7.0'
+    implementation 'com.artemzin.rxjava:proguard-rules:1.3.3.0'
     compileOnly "com.android.support:support-annotations:$supportLibraryVersion"
 
     testCompileOnly "com.android.support:support-annotations:$supportLibraryVersion"


### PR DESCRIPTION
Update Rx ProGuard Rules and get rid of the related lint warning.