### PR TITLE
Create PublishPlugin to easify publishing

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    kotlin("jvm") version "1.3.20"
+    `java-gradle-plugin`
+}
+
+repositories {
+    google()
+    jcenter()
+}
+
+dependencies {
+    implementation(kotlin("stdlib-jdk8"))
+    implementation("guru.stefma.bintrayrelease:bintrayrelease:1.1.1")
+}
+
+gradlePlugin {
+    plugins {
+        create("bintrayPublish") {
+            id = "net.grandcentrix.gradle.publish"
+            implementationClass = "net.grandcentrix.gradle.publish.PublishPlugin"
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/net/grandcentrix/gradle/publish/PublishPlugin.kt
+++ b/buildSrc/src/main/kotlin/net/grandcentrix/gradle/publish/PublishPlugin.kt
@@ -1,0 +1,26 @@
+package net.grandcentrix.gradle.publish
+
+import guru.stefma.androidartifacts.ArtifactsExtension
+import guru.stefma.bintrayrelease.PublishExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class PublishPlugin : Plugin<Project> {
+
+    override fun apply(project: Project) {
+        with(project.pluginManager) {
+            withPlugin("com.android.library") {
+                apply("guru.stefma.bintrayrelease")
+                (project.extensions.getByName("publish") as PublishExtension).apply {
+                    userOrg = "grandcentrix"
+                    uploadName = "ThirtyInch"
+                    website = "https://github.com/grandcentrix/ThirtyInch"
+                    desc = "a Model View Presenter library for Android"
+                }
+                (project.extensions.getByName("androidArtifact") as ArtifactsExtension).apply {
+                    artifactId = project.name
+                }
+            }
+        }
+    }
+}

--- a/gradle/setupPublishExtension.gradle
+++ b/gradle/setupPublishExtension.gradle
@@ -1,6 +1,0 @@
-publish {
-    userOrg = "grandcentrix"
-    uploadName = "ThirtyInch"
-    website = "https://github.com/grandcentrix/ThirtyInch"
-    desc = "a Model View Presenter library for Android"
-}

--- a/thirtyinch-kotlin/build.gradle
+++ b/thirtyinch-kotlin/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "com.android.library"
 apply plugin: "org.jetbrains.kotlin.android"
-apply plugin: 'guru.stefma.bintrayrelease'
+apply plugin: 'net.grandcentrix.gradle.publish'
 
 android {
     compileSdkVersion COMPILE_SDK_VERSION
@@ -29,10 +29,4 @@ dependencies {
 
     testImplementation "junit:junit:$junitVersion"
     testImplementation "com.nhaarman:mockito-kotlin:1.5.0"
-}
-
-// For uploading to bintray
-apply from: '../gradle/setupPublishExtension.gradle'
-androidArtifact {
-    artifactId = 'thirtyinch-kotlin'
 }

--- a/thirtyinch-logginginterceptor/build.gradle
+++ b/thirtyinch-logginginterceptor/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'com.android.library'
-apply plugin: 'guru.stefma.bintrayrelease'
+apply plugin: 'net.grandcentrix.gradle.publish'
 
 android {
     compileSdkVersion COMPILE_SDK_VERSION
@@ -29,10 +29,4 @@ dependencies {
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.assertj:assertj-core:$assertjVersion"
-}
-
-// For uploading to bintray
-apply from: '../gradle/setupPublishExtension.gradle'
-androidArtifact {
-    artifactId = 'thirtyinch-logginginterceptor'
 }

--- a/thirtyinch-rx/build.gradle
+++ b/thirtyinch-rx/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'com.android.library'
-apply plugin: 'guru.stefma.bintrayrelease'
+apply plugin: 'net.grandcentrix.gradle.publish'
 
 android {
     compileSdkVersion COMPILE_SDK_VERSION
@@ -32,10 +32,4 @@ dependencies {
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.assertj:assertj-core:$assertjVersion"
-}
-
-// For uploading to bintray
-apply from: '../gradle/setupPublishExtension.gradle'
-androidArtifact {
-    artifactId = 'thirtyinch-rx'
 }

--- a/thirtyinch-rx2/build.gradle
+++ b/thirtyinch-rx2/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'com.android.library'
-apply plugin: 'guru.stefma.bintrayrelease'
+apply plugin: 'net.grandcentrix.gradle.publish'
 
 android {
     compileSdkVersion COMPILE_SDK_VERSION
@@ -30,10 +30,4 @@ dependencies {
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.assertj:assertj-core:$assertjVersion"
-}
-
-// For uploading to bintray
-apply from: '../gradle/setupPublishExtension.gradle'
-androidArtifact {
-    artifactId = 'thirtyinch-rx2'
 }

--- a/thirtyinch/build.gradle
+++ b/thirtyinch/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'com.android.library'
-apply plugin: 'guru.stefma.bintrayrelease'
+apply plugin: 'net.grandcentrix.gradle.publish'
 
 android {
     compileSdkVersion COMPILE_SDK_VERSION
@@ -48,12 +48,6 @@ dependencies {
     androidTestImplementation "org.assertj:assertj-core:$assertjVersion"
 
     lintChecks project(path: ":thirtyinch-lint", configuration: "lintChecks")
-}
-
-// For uploading to bintray
-apply from: '../gradle/setupPublishExtension.gradle'
-androidArtifact {
-    artifactId = 'thirtyinch'
 }
 
 task copyLintJar(type: Copy) {


### PR DESCRIPTION
This will create an Publish Gradle Plugin to get rid of this ugly gradle script ...

To test this; just run `androidArtifactDebug` and take a look into your local maven.
Should be the same output as in the current `master` branch (by running `androidArtifactDebug` of course)