### PR TITLE
Fix wrong usage of hasLifecycleMethodBeenCalled in TiCoroutineScope

### DIFF
--- a/thirtyinch-kotlin-coroutines/src/main/java/net/grandcentrix/thirtyinch/kotlin/coroutines/TiCoroutineScope.kt
+++ b/thirtyinch-kotlin-coroutines/src/main/java/net/grandcentrix/thirtyinch/kotlin/coroutines/TiCoroutineScope.kt
@@ -41,7 +41,7 @@ class TiCoroutineScope(
 
     init {
         presenter.addLifecycleObserver { state, hasLifecycleMethodBeenCalled ->
-            if (!hasLifecycleMethodBeenCalled) return@addLifecycleObserver
+            if (hasLifecycleMethodBeenCalled) return@addLifecycleObserver
 
             when {
                 state == DESTROYED -> onPresenterDestroyedJob.cancel()

--- a/thirtyinch-kotlin-coroutines/src/test/java/net/grandcentrix/thirtyinch/kotlin/coroutines/TiCoroutineScopeTest.kt
+++ b/thirtyinch-kotlin-coroutines/src/test/java/net/grandcentrix/thirtyinch/kotlin/coroutines/TiCoroutineScopeTest.kt
@@ -1,5 +1,6 @@
 package net.grandcentrix.thirtyinch.kotlin.coroutines
 
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -77,6 +78,31 @@ class TiCoroutineScopeTest {
             assertTrue(exe.message == "launchUntilViewDetaches can only be called when there is a view attached")
         }
     }
+
+    @Test
+    fun `launching a job in onAttachView doesn't throw`() {
+        lateinit var job: Job
+        val presenter = Presenter2().apply {
+            val scope = TiCoroutineScope(this, coroutineContext)
+            jobLauncher = {
+                job = scope.launchUntilViewDetaches { }
+            }
+        }
+
+        presenter.test().attachView(view)
+
+        assertTrue(job.isActive)
+    }
 }
 
-class Presenter : TiPresenter<TiView>()
+private class Presenter : TiPresenter<TiView>()
+
+private class Presenter2 : TiPresenter<TiView>() {
+
+    lateinit var jobLauncher: (() -> Unit)
+
+    override fun onAttachView(view: TiView) {
+        super.onAttachView(view)
+        jobLauncher()
+    }
+}


### PR DESCRIPTION
I tried to use the new coroutines module and launch a job in `onAttachView()` via `TiCoroutineScope.launchUntilViewDetaches {}`, but got an exception that the view is not attached.

Due to the check `if (!hasLifecycleMethodBeenCalled) return@addLifecycleObserver`, to not call things twice, the required `Job` was indeed not initialized, yet.

Now we avoid the second lifecycle call instead. Practically this means we initialize everything **before**  `onAttachView()` is called and not **after**.