### PR TITLE
add testAttachView() extension function

### DIFF
--- a/thirtyinch-kotlin/src/main/java/net/grandcentrix/thirtyinch/kotlin/test/TiPresenter.kt
+++ b/thirtyinch-kotlin/src/main/java/net/grandcentrix/thirtyinch/kotlin/test/TiPresenter.kt
@@ -1,0 +1,12 @@
+package net.grandcentrix.thirtyinch.kotlin.test
+
+import net.grandcentrix.thirtyinch.TiPresenter
+import net.grandcentrix.thirtyinch.TiView
+
+/**
+ * Convenience function to use in tests.
+ *
+ * Returns this [TiPresenter] with attached [mockView].
+ */
+fun <V : TiView, P : TiPresenter<V>> P.testAttachView(mockView: V): P =
+        apply { test().run { attachView(mockView) } }


### PR DESCRIPTION
This adds a convenience extension function which reduces tests boilerplate.
It is useful in typical tests where we always assume that the presenter has a view already attached and just want to test different presenter functions.