### PR TITLE
Use dist trusty to build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: android
-jdk:
-    - oraclejdk8
+dist: trusty
 
 android:
   components:


### PR DESCRIPTION
According to their (TravisCI) **current** documentation only "trusty" can build android projects:
![Bildschirmfoto 2019-07-26 um 08 10 26](https://user-images.githubusercontent.com/10229883/61930023-e25c0e00-af7c-11e9-96b7-85e29a6bb4ed.png)

We don't used any specific ubuntu distribution. Therefore they picked (in the failing builds at #194) always an very old distribution:
![Bildschirmfoto 2019-07-26 um 08 09 18](https://user-images.githubusercontent.com/10229883/61930077-0a4b7180-af7d-11e9-96c4-c93222f0ba38.png)

Hope for the best 🤞 