### PR TITLE
Update RELEASE.md to use bundle*Aar task

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,11 +14,11 @@ Before we release a new version we have to make sure that we increase the `VERSI
 At this time we don't provide public `SNAPSHOT` releases.
 Anyway. If you want to use the latest and greatest features of Ti (or just want to build it by yourself because it is fun) you can "publish" Ti directly into your `mavenLocal()`. To do it you can run either:
 ```
-./gradlew clean bundleRelease bintrayUpload -PbintrayUser=MockedUserName -PbintrayKey=MockedKey -PdryRun=true
+./gradlew clean bundleReleaseAar bintrayUpload -PbintrayUser=MockedUserName -PbintrayKey=MockedKey -PdryRun=true
 ```
 (MockedUserName and MockedKey can be any value 😉)
 
 Or you can use directly the `publishReleasePublicationToMavenLocal` task:
 ```
-./gradlew clean bundleRelease publishReleasePublicationToMavenLocal
+./gradlew clean bundleReleaseAar publishReleasePublicationToMavenLocal
 ```


### PR DESCRIPTION
Fixes #186 

You can check this by doing the following:
First run `clean bundleRelease`.
Checkout the `thirtyinch/build/outputs/` dir. There is no **aar**  directory which contains the **aar**.

Now run the `bundleReleaseAar` task and check the same directory.
The aar directory is available and the aar file