### PR TITLE
make Kotlin version consistent & bump version for 1.0.0 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = "1.3.41"
+    ext.kotlin_version = "1.3.61"
     repositories {
         google()
         jcenter()
@@ -29,10 +29,10 @@ allprojects {
 }
 
 ext {
-    VERSION_NAME = "0.9.7-SNAPSHOT"
-    VERSION_CODE = 14
+    VERSION_NAME = "1.0.0"
+    VERSION_CODE = 15
     MIN_SDK_VERSION = 14
-    // If you change the SDK version don't forgot to update .travis.yml
+    // If you change the SDK version don't forget to update .travis.yml
     TARGET_SDK_VERSION = 28
     COMPILE_SDK_VERSION = 28
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.3.41"
+    kotlin("jvm") version "1.3.61"
     `java-gradle-plugin`
 }
 


### PR DESCRIPTION
Kotlin version for build logic was 1.3.41, although the actual project code was on 1.3.61.

Also bumps version in preparation for the 1.0.0 release.